### PR TITLE
Add uv for Python scripts to manage dependencies on the fly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea/
 3rdparty/*
 build
 log

--- a/scripts/csv2feather.py
+++ b/scripts/csv2feather.py
@@ -1,4 +1,10 @@
 #!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#   "pandas",
+# ]
+# ///
 
 import sys
 import pandas as pd


### PR DESCRIPTION
I suggest using uv ( https://docs.astral.sh/uv/guides/scripts/#declaring-script-dependencies  ) for script-level dependency management. It allows you to declare all dependencies directly in the script file, which fits a C++ project well when Python scripts are used only as supporting tools.

## Example

```
uv run scripts/csv2feather.py <input> <output>
```
