### PR TITLE
Add github workflow for trigger tests during PR phase

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Cache build artifacts
+        uses: actions/cache@v4
+        with:
+          path: |
+            build
+            3rdparty
+          key: ${{ runner.os }}-cmake-${{ hashFiles('CMakeLists.txt', 'cmake/**', 'src/**', 'test/**') }}
+          restore-keys: |
+            ${{ runner.os }}-cmake-
+
+      - name: Configure CMake
+        run: cmake -B build -S . -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=ON
+
+      - name: Build
+        run: cmake --build build -j$(nproc)
+
+      - name: Run tests
+        run: ctest --test-dir build --output-on-failure -j$(nproc)


### PR DESCRIPTION
The pipeline triggers on pushes and pull requests to main, checks out the repository, restores a cache of build artifacts and third-party code, configures a Release CMake build with tests, compiles, then executes ctest in parallel. 

## Future work  

Introduce compiler cache (ccache), improve cache keys to avoid fragile build directory reuse, add compiler/OS matrix, configure stricter test parallelism, enforce job timeouts, and optionally enable sanitizers and coverage reporting.