### PR TITLE
Add implementation of the data-ingestion layer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@ build
 log
 .claude
 CLAUDE.md
-
+data/
 
 ### C++ ###
 # Prerequisites
@@ -279,3 +279,4 @@ __marimo__/
 # Ignore all local history of files
 .history
 .ionide
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -24,62 +24,53 @@
 
 ## OS
 
-Our primary platform is Linux, but nothing prevents it to be built and run on other OS.
-The following commands are for Linux users.
-Other users are encouraged to add the corresponding instructions for required steps in this README.
+Our primary platform is Linux, but the project also builds and runs on macOS.
 
-## Build
+### Linux
 
 Install dependencies once:
 
-```
+```bash
 sudo apt install -y cmake g++
 ```
 
-Build using cmake:
+### macOS
 
+Install dependencies once via [Homebrew](https://brew.sh):
+
+```bash
+brew install cmake
 ```
-cmake -B build -S .
+
+Xcode Command Line Tools provide the compiler (`clang++`). Install them if you haven't already:
+
+```bash
+xcode-select --install
+```
+
+## Build
+
+```bash
+cmake -B build -S . -DBUILD_TESTS=ON
 cmake --build build -j
-```
-
-or
-
-```
-mkdir -p build
-pushd build
-cmake ..
-make -j VERBOSE=1
-popd
 ```
 
 ## Test
 
-To run unit tests:
-
-```
-ctest --test-dir build -j
+```bash
+ctest --test-dir build --output-on-failure -j
 ```
 
-or
+Or run the test binary directly (supports Catch2 tag filters):
 
-```
-pushd build
-ctest -j
-popd
-```
-
-or
-
-```
-build/bin/test/back-tester-tests
+```bash
+build/bin/test/back-tester-tests                  # all tests
+build/bin/test/back-tester-tests "[BasicTypes]"   # single tag
 ```
 
 ## Run
 
-Back-tester:
-
-```
+```bash
 build/bin/back-tester
 ```
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,13 @@ build/bin/test/back-tester-tests "[BasicTypes]"   # single tag
 ## Run
 
 ```bash
-build/bin/back-tester
+build/bin/back-tester <path-to-daily-ndjson-file>
+```
+
+Example:
+
+```bash
+build/bin/back-tester data/XEUR-20260409-HTT6HHLT6R/xeur-eobi-20260309.mbo.json
 ```
 
 ## Contributing

--- a/cmake/ThirdPartyLibs.cmake
+++ b/cmake/ThirdPartyLibs.cmake
@@ -39,3 +39,23 @@ target_link_libraries(${TGT} PUBLIC INTERFACE
     $<$<CONFIG:Release>:-lCatch2Main -lCatch2>
 )
 
+# ---------------------------------------------------------------------------------------
+# nlohmann/json - JSON for Modern C++ (header-only)
+ExternalProject_Add(
+    nlohmann_json
+    GIT_REPOSITORY https://github.com/nlohmann/json.git
+    GIT_TAG v3.11.3
+    GIT_SHALLOW TRUE
+    GIT_PROGRESS TRUE
+    SOURCE_DIR "${CMAKE_SOURCE_DIR}/3rdparty/nlohmann_json"
+    BINARY_DIR "${CMAKE_BINARY_DIR}/3rdparty/nlohmann_json"
+    CMAKE_ARGS ${FORWARDED_CMAKE_ARGS} -DJSON_BuildTests=OFF
+    BUILD_COMMAND $(MAKE)
+    INSTALL_COMMAND $(MAKE) -s DESTDIR=${DESTDIR} install
+)
+
+set(TGT nlohmann-json)
+add_library(${TGT} INTERFACE)
+add_dependencies(${TGT} nlohmann_json)
+target_include_directories(${TGT} SYSTEM PUBLIC INTERFACE ${CMAKE_BINARY_DIR}/include)
+

--- a/src/common/MarketDataEvent.hpp
+++ b/src/common/MarketDataEvent.hpp
@@ -1,0 +1,48 @@
+#pragma once
+
+#include "common/BasicTypes.hpp"
+
+#include <cstdint>
+#include <string>
+
+namespace cmf {
+
+// Order event actions from Databento MBO feed
+// Maps to the single-char 'action' field in the NDJSON data
+enum class Action : char {
+  Add = 'A',    // new order inserted into the book
+  Modify = 'M', // order price and/or size changed
+  Cancel = 'C', // order fully or partially cancelled
+  Clear = 'R',  // all resting orders for the instrument removed
+  Trade = 'T',  // aggressing order traded (does not affect book)
+  Fill = 'F',   // resting order filled (does not affect book)
+  None = 'N'    // no book effect, may carry flags or info
+};
+
+// A single L3 market-by-order event parsed from a Databento NDJSON record.
+// One line of the daily file becomes one MarketDataEvent.
+struct MarketDataEvent {
+  NanoTime tsRecv{};  // Databento receive timestamp (index timestamp)
+  NanoTime tsEvent{}; // exchange event timestamp
+
+  Action action{Action::None};
+  Side side{Side::None};
+
+  Price price{};   // order price (0 or NaN when null in source)
+  Quantity size{}; // order quantity
+
+  OrderId orderId{}; // exchange-assigned order id
+
+  std::uint32_t instrumentId{}; // Databento instrument id (unique per day)
+  std::uint16_t channelId{};    // exchange channel / partition
+  std::uint16_t publisherId{};  // Databento publisher id
+  std::uint8_t flags{};         // bitfield (F_LAST, F_TOB, F_SNAPSHOT, etc.)
+  std::uint8_t rtype{};         // record type (160 = MBO)
+
+  std::int32_t tsInDelta{}; // nanoseconds: ts_recv - publisher send time
+  std::uint32_t sequence{}; // exchange sequence number
+
+  std::string symbol; // human-readable instrument symbol
+};
+
+} // namespace cmf

--- a/src/common/MarketDataEvent.hpp
+++ b/src/common/MarketDataEvent.hpp
@@ -3,6 +3,7 @@
 #include "common/BasicTypes.hpp"
 
 #include <cstdint>
+#include <ostream>
 #include <string>
 
 namespace cmf {
@@ -18,6 +19,38 @@ enum class Action : char {
   Fill = 'F',   // resting order filled (does not affect book)
   None = 'N'    // no book effect, may carry flags or info
 };
+
+inline std::ostream &operator<<(std::ostream &os, Action a) {
+  switch (a) {
+  case Action::Add:
+    return os << "Add";
+  case Action::Modify:
+    return os << "Modify";
+  case Action::Cancel:
+    return os << "Cancel";
+  case Action::Clear:
+    return os << "Clear";
+  case Action::Trade:
+    return os << "Trade";
+  case Action::Fill:
+    return os << "Fill";
+  case Action::None:
+    return os << "None";
+  }
+  return os << "Unknown";
+}
+
+inline std::ostream &operator<<(std::ostream &os, Side s) {
+  switch (s) {
+  case Side::Buy:
+    return os << "Buy";
+  case Side::Sell:
+    return os << "Sell";
+  case Side::None:
+    return os << "None";
+  }
+  return os << "Unknown";
+}
 
 // A single L3 market-by-order event parsed from a Databento NDJSON record.
 // One line of the daily file becomes one MarketDataEvent.
@@ -44,5 +77,13 @@ struct MarketDataEvent {
 
   std::string symbol; // human-readable instrument symbol
 };
+
+inline std::ostream &operator<<(std::ostream &os, const MarketDataEvent &e) {
+  os << "ts_recv=" << e.tsRecv << " ts_event=" << e.tsEvent
+     << " action=" << e.action << " side=" << e.side << " price=" << e.price
+     << " size=" << e.size << " order_id=" << e.orderId
+     << " symbol=" << e.symbol;
+  return os;
+}
 
 } // namespace cmf

--- a/src/main/CMakeLists.txt
+++ b/src/main/CMakeLists.txt
@@ -1,5 +1,5 @@
-file(GLOB SRC CONFIGURE_DEPENDS *.cpp)
-list(REMOVE_ITEM SRC main.cpp)
+file(GLOB_RECURSE SRC CONFIGURE_DEPENDS *.cpp)
+list(REMOVE_ITEM SRC ${CMAKE_CURRENT_SOURCE_DIR}/main.cpp)
 
 # static library
 set(TARGET back-tester-lib)

--- a/src/main/CMakeLists.txt
+++ b/src/main/CMakeLists.txt
@@ -6,6 +6,7 @@ set(TARGET back-tester-lib)
 add_library(${TARGET} STATIC ${SRC})
 target_link_libraries(${TARGET} PUBLIC
     back-tester-common
+    nlohmann-json
 )
 
 # executable

--- a/src/main/ingestion/MarketDataParser.cpp
+++ b/src/main/ingestion/MarketDataParser.cpp
@@ -1,0 +1,45 @@
+#include "main/ingestion/MarketDataParser.hpp"
+
+#include <fstream>
+#include <string>
+
+namespace cmf {
+
+std::size_t MarketDataParser::parseFile(const std::string &filePath,
+                                        EventCallback callback) {
+  // TODO: open file, read line-by-line, call parseLine, invoke callback
+  return 0;
+}
+
+bool MarketDataParser::parseLine(std::string_view line,
+                                 MarketDataEvent &outEvent) {
+  // TODO: JSON parsing — extract fields into outEvent
+  return false;
+}
+
+NanoTime MarketDataParser::parseTimestamp(std::string_view tsStr) {
+  // TODO: convert ISO-8601 string to nanoseconds since epoch
+  return 0;
+}
+
+Action MarketDataParser::parseAction(char ch) {
+  // TODO: map 'A','M','C','R','T','F','N' to Action enum
+  return Action::None;
+}
+
+Side MarketDataParser::parseSide(char ch) {
+  // TODO: map 'B' -> Buy, 'A' -> Sell, 'N' -> None
+  return Side::None;
+}
+
+Price MarketDataParser::parsePrice(std::string_view priceStr) {
+  // TODO: parse decimal string to double, handle null
+  return 0.0;
+}
+
+OrderId MarketDataParser::parseOrderId(std::string_view idStr) {
+  // TODO: parse uint64 string
+  return 0;
+}
+
+} // namespace cmf

--- a/src/main/ingestion/MarketDataParser.cpp
+++ b/src/main/ingestion/MarketDataParser.cpp
@@ -5,39 +5,42 @@
 
 namespace cmf {
 
-std::size_t MarketDataParser::parseFile(const std::string &filePath,
-                                        EventCallback callback) {
+std::size_t
+MarketDataParser::parseFile([[maybe_unused]] const std::string &filePath,
+                            [[maybe_unused]] EventCallback callback) {
   // TODO: open file, read line-by-line, call parseLine, invoke callback
   return 0;
 }
 
-bool MarketDataParser::parseLine(std::string_view line,
-                                 MarketDataEvent &outEvent) {
+bool MarketDataParser::parseLine([[maybe_unused]] std::string_view line,
+                                 [[maybe_unused]] MarketDataEvent &outEvent) {
   // TODO: JSON parsing — extract fields into outEvent
   return false;
 }
 
-NanoTime MarketDataParser::parseTimestamp(std::string_view tsStr) {
+NanoTime
+MarketDataParser::parseTimestamp([[maybe_unused]] std::string_view tsStr) {
   // TODO: convert ISO-8601 string to nanoseconds since epoch
   return 0;
 }
 
-Action MarketDataParser::parseAction(char ch) {
+Action MarketDataParser::parseAction([[maybe_unused]] char ch) {
   // TODO: map 'A','M','C','R','T','F','N' to Action enum
   return Action::None;
 }
 
-Side MarketDataParser::parseSide(char ch) {
+Side MarketDataParser::parseSide([[maybe_unused]] char ch) {
   // TODO: map 'B' -> Buy, 'A' -> Sell, 'N' -> None
   return Side::None;
 }
 
-Price MarketDataParser::parsePrice(std::string_view priceStr) {
+Price MarketDataParser::parsePrice([[maybe_unused]] std::string_view priceStr) {
   // TODO: parse decimal string to double, handle null
   return 0.0;
 }
 
-OrderId MarketDataParser::parseOrderId(std::string_view idStr) {
+OrderId
+MarketDataParser::parseOrderId([[maybe_unused]] std::string_view idStr) {
   // TODO: parse uint64 string
   return 0;
 }

--- a/src/main/ingestion/MarketDataParser.cpp
+++ b/src/main/ingestion/MarketDataParser.cpp
@@ -1,48 +1,162 @@
 #include "main/ingestion/MarketDataParser.hpp"
 
+#include <charconv>
+#include <ctime>
 #include <fstream>
+#include <nlohmann/json.hpp>
 #include <string>
 
 namespace cmf {
 
-std::size_t
-MarketDataParser::parseFile([[maybe_unused]] const std::string &filePath,
-                            [[maybe_unused]] EventCallback callback) {
-  // TODO: open file, read line-by-line, call parseLine, invoke callback
-  return 0;
+std::size_t MarketDataParser::parseFile(const std::string &filePath,
+                                        EventCallback callback) {
+  std::ifstream file(filePath);
+  if (!file.is_open()) {
+    return 0;
+  }
+
+  std::size_t count = 0;
+  std::string line;
+  MarketDataEvent event;
+
+  while (std::getline(file, line)) {
+    if (parseLine(line, event)) {
+      callback(event);
+      ++count;
+    }
+  }
+
+  return count;
 }
 
-bool MarketDataParser::parseLine([[maybe_unused]] std::string_view line,
-                                 [[maybe_unused]] MarketDataEvent &outEvent) {
-  // TODO: JSON parsing — extract fields into outEvent
-  return false;
+bool MarketDataParser::parseLine(std::string_view line,
+                                 MarketDataEvent &outEvent) {
+  if (line.empty() ||
+      line.find_first_not_of(" \t\r\n") == std::string_view::npos) {
+    return false;
+  }
+
+  nlohmann::json j;
+  try {
+    j = nlohmann::json::parse(line);
+  } catch (const nlohmann::json::parse_error &) {
+    return false;
+  }
+
+  // action is required
+  if (!j.contains("action") || !j["action"].is_string()) {
+    return false;
+  }
+
+  const auto &hd = j["hd"];
+
+  outEvent.tsRecv = parseTimestamp(j["ts_recv"].get<std::string_view>());
+  outEvent.tsEvent = parseTimestamp(hd["ts_event"].get<std::string_view>());
+
+  outEvent.action = parseAction(j["action"].get<std::string_view>()[0]);
+  outEvent.side = parseSide(j["side"].get<std::string_view>()[0]);
+
+  if (j["price"].is_null()) {
+    outEvent.price = 0.0;
+  } else {
+    outEvent.price = parsePrice(j["price"].get<std::string_view>());
+  }
+
+  outEvent.size = j["size"].get<double>();
+  outEvent.orderId = parseOrderId(j["order_id"].get<std::string_view>());
+
+  outEvent.instrumentId = hd["instrument_id"].get<std::uint32_t>();
+  outEvent.channelId = j["channel_id"].get<std::uint16_t>();
+  outEvent.publisherId = hd["publisher_id"].get<std::uint16_t>();
+  outEvent.flags = j["flags"].get<std::uint8_t>();
+  outEvent.rtype = hd["rtype"].get<std::uint8_t>();
+
+  outEvent.tsInDelta = j["ts_in_delta"].get<std::int32_t>();
+  outEvent.sequence = j["sequence"].get<std::uint32_t>();
+
+  outEvent.symbol = j["symbol"].get<std::string>();
+
+  return true;
 }
 
-NanoTime
-MarketDataParser::parseTimestamp([[maybe_unused]] std::string_view tsStr) {
-  // TODO: convert ISO-8601 string to nanoseconds since epoch
-  return 0;
+// Parses "2026-03-09T00:03:00.129732099Z" into nanoseconds since UNIX epoch.
+NanoTime MarketDataParser::parseTimestamp(std::string_view tsStr) {
+  // Parse: YYYY-MM-DDThh:mm:ss.nnnnnnnnnZ
+  std::tm tm{};
+  tm.tm_year = (tsStr[0] - '0') * 1000 + (tsStr[1] - '0') * 100 +
+               (tsStr[2] - '0') * 10 + (tsStr[3] - '0') - 1900;
+  tm.tm_mon = (tsStr[5] - '0') * 10 + (tsStr[6] - '0') - 1;
+  tm.tm_mday = (tsStr[8] - '0') * 10 + (tsStr[9] - '0');
+  tm.tm_hour = (tsStr[11] - '0') * 10 + (tsStr[12] - '0');
+  tm.tm_min = (tsStr[14] - '0') * 10 + (tsStr[15] - '0');
+  tm.tm_sec = (tsStr[17] - '0') * 10 + (tsStr[18] - '0');
+
+  std::time_t epochSecs = timegm(&tm);
+
+  // Parse the fractional seconds (up to 9 digits after the '.')
+  NanoTime nanos = 0;
+  if (tsStr.size() > 20 && tsStr[19] == '.') {
+    auto fracStart = tsStr.data() + 20;
+    // Find end of digits (before 'Z')
+    auto fracEnd = tsStr.data() + tsStr.size();
+    if (tsStr.back() == 'Z') {
+      --fracEnd;
+    }
+    std::size_t digits = static_cast<std::size_t>(fracEnd - fracStart);
+
+    std::int64_t frac = 0;
+    std::from_chars(fracStart, fracEnd, frac);
+
+    // Pad to 9 digits: if fewer digits, multiply up
+    for (std::size_t i = digits; i < 9; ++i) {
+      frac *= 10;
+    }
+    nanos = frac;
+  }
+
+  return static_cast<NanoTime>(epochSecs) * 1'000'000'000LL + nanos;
 }
 
-Action MarketDataParser::parseAction([[maybe_unused]] char ch) {
-  // TODO: map 'A','M','C','R','T','F','N' to Action enum
-  return Action::None;
+Action MarketDataParser::parseAction(char ch) {
+  switch (ch) {
+  case 'A':
+    return Action::Add;
+  case 'M':
+    return Action::Modify;
+  case 'C':
+    return Action::Cancel;
+  case 'R':
+    return Action::Clear;
+  case 'T':
+    return Action::Trade;
+  case 'F':
+    return Action::Fill;
+  default:
+    return Action::None;
+  }
 }
 
-Side MarketDataParser::parseSide([[maybe_unused]] char ch) {
-  // TODO: map 'B' -> Buy, 'A' -> Sell, 'N' -> None
-  return Side::None;
+Side MarketDataParser::parseSide(char ch) {
+  switch (ch) {
+  case 'B':
+    return Side::Buy;
+  case 'A':
+    return Side::Sell;
+  default:
+    return Side::None;
+  }
 }
 
-Price MarketDataParser::parsePrice([[maybe_unused]] std::string_view priceStr) {
-  // TODO: parse decimal string to double, handle null
-  return 0.0;
+Price MarketDataParser::parsePrice(std::string_view priceStr) {
+  double val = 0.0;
+  std::from_chars(priceStr.data(), priceStr.data() + priceStr.size(), val);
+  return val;
 }
 
-OrderId
-MarketDataParser::parseOrderId([[maybe_unused]] std::string_view idStr) {
-  // TODO: parse uint64 string
-  return 0;
+OrderId MarketDataParser::parseOrderId(std::string_view idStr) {
+  std::uint64_t val = 0;
+  std::from_chars(idStr.data(), idStr.data() + idStr.size(), val);
+  return val;
 }
 
 } // namespace cmf

--- a/src/main/ingestion/MarketDataParser.hpp
+++ b/src/main/ingestion/MarketDataParser.hpp
@@ -1,0 +1,46 @@
+#pragma once
+
+#include "common/MarketDataEvent.hpp"
+
+#include <cstddef>
+#include <functional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace cmf {
+
+// Callback type: receives each parsed event.
+// The dispatcher (caller) decides what to do — print, enqueue, update LOB, etc.
+using EventCallback = std::function<void(const MarketDataEvent &)>;
+
+// Parses Databento NDJSON L3 files into MarketDataEvent objects.
+//
+// Usage:
+//   MarketDataParser parser;
+//   parser.parseFile("path/to/daily.mbo.json", [](const MarketDataEvent& e) {
+//       processMarketDataEvent(e);
+//   });
+//
+class MarketDataParser {
+public:
+  MarketDataParser() = default;
+
+  // Parse a single daily NDJSON file, invoking callback for every valid event.
+  // Returns the total number of events successfully parsed.
+  std::size_t parseFile(const std::string &filePath, EventCallback callback);
+
+  // Parse one NDJSON line into a MarketDataEvent.
+  // Returns true on success, false if the line is malformed or empty.
+  static bool parseLine(std::string_view line, MarketDataEvent &outEvent);
+
+private:
+  // Field-level helpers — each extracts one piece from the JSON line.
+  static NanoTime parseTimestamp(std::string_view tsStr);
+  static Action parseAction(char ch);
+  static Side parseSide(char ch);
+  static Price parsePrice(std::string_view priceStr);
+  static OrderId parseOrderId(std::string_view idStr);
+};
+
+} // namespace cmf

--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -1,15 +1,66 @@
 // main function for the back-tester app
 // please, keep it minimalistic
 
-#include "common/BasicTypes.hpp"
+#include "common/MarketDataEvent.hpp"
+#include "main/ingestion/MarketDataParser.hpp"
 
+#include <deque>
 #include <iostream>
+#include <string>
 
 using namespace cmf;
 
-int main([[maybe_unused]] int argc, [[maybe_unused]] const char *argv[]) {
+void processMarketDataEvent(const MarketDataEvent &event) {
+  std::cout << event << "\n";
+}
+
+int main(int argc, const char *argv[]) {
+  if (argc != 2) {
+    std::cerr << "Usage: back-tester <path-to-daily-ndjson-file>\n";
+    return 1;
+  }
+
   try {
-    std::cout << "Hell! Oh, world!" << std::endl;
+    const std::string filePath = argv[1];
+
+    NanoTime firstTs = 0;
+    NanoTime lastTs = 0;
+    std::size_t totalCount = 0;
+
+    std::deque<MarketDataEvent> first10;
+    std::deque<MarketDataEvent> last10;
+
+    MarketDataParser parser;
+    totalCount = parser.parseFile(filePath, [&](const MarketDataEvent &event) {
+      if (first10.size() < 10) {
+        first10.push_back(event);
+      }
+      if (last10.size() == 10) {
+        last10.pop_front();
+      }
+      last10.push_back(event);
+
+      if (firstTs == 0) {
+        firstTs = event.tsRecv;
+      }
+      lastTs = event.tsRecv;
+    });
+
+    std::cout << "=== First 10 events ===\n";
+    for (const auto &e : first10) {
+      processMarketDataEvent(e);
+    }
+
+    std::cout << "\n=== Last 10 events ===\n";
+    for (const auto &e : last10) {
+      processMarketDataEvent(e);
+    }
+
+    std::cout << "\n=== Summary ===\n"
+              << "Total messages processed: " << totalCount << "\n"
+              << "First timestamp: " << firstTs << "\n"
+              << "Last timestamp:  " << lastTs << "\n";
+
   } catch (std::exception &ex) {
     std::cerr << "Back-tester threw an exception: " << ex.what() << std::endl;
     return 1;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -19,7 +19,7 @@ add_executable(${TARGET} ${TEST_SRC})
 # Link against the necessary libraries
 target_link_libraries(${TARGET} PRIVATE
     Catch2-static-lib
-    back-tester-common
+    back-tester-lib
 )
 
 # Register the tests with CTest

--- a/test/MarketDataParserTest.cpp
+++ b/test/MarketDataParserTest.cpp
@@ -1,0 +1,267 @@
+// tests for MarketDataParser — standard task
+//
+// Uses a TempFile to create a mock NDJSON file with a mix of:
+//   - valid messages covering every action type (R, A, C, M, T, F)
+//   - malformed / empty / incomplete lines that the parser must skip
+
+#include "main/ingestion/MarketDataParser.hpp"
+
+#include "TempFile.hpp"
+#include "catch2/catch_all.hpp"
+
+#include <cmath>
+#include <fstream>
+#include <limits>
+#include <string>
+#include <vector>
+
+using namespace cmf;
+using Catch::Approx;
+
+// ── Fixture data ────────────────────────────────────────────────────────
+// Real Databento records (pretty_px / pretty_ts enabled) plus hand-crafted
+// invalid lines.  Each valid line is taken from the actual XEUR EOBI feed
+// or modelled closely on it so the field values are realistic.
+
+// Line 1 — Clear (R), null price, side N
+static constexpr const char *kClearLine =
+    R"({"ts_recv":"2026-03-09T00:03:00.129732099Z","hd":{"ts_event":"2026-03-09T00:00:00.000000000Z","rtype":160,"publisher_id":101,"instrument_id":442},"action":"R","side":"N","price":null,"size":0,"channel_id":23,"order_id":"0","flags":8,"ts_in_delta":0,"sequence":0,"symbol":"FCEU SI 20260316 PS"})";
+
+// Line 2 — Add (A), buy side
+static constexpr const char *kAddBuyLine =
+    R"({"ts_recv":"2026-03-09T00:03:00.129732099Z","hd":{"ts_event":"2026-03-09T00:00:00.000000000Z","rtype":160,"publisher_id":101,"instrument_id":442},"action":"A","side":"B","price":"1.152800000","size":20,"channel_id":23,"order_id":"10996386599372464268","flags":0,"ts_in_delta":2634,"sequence":61463,"symbol":"FCEU SI 20260316 PS"})";
+
+// Line 3 — Add (A), ask/sell side, F_LAST flag (128)
+static constexpr const char *kAddSellLine =
+    R"({"ts_recv":"2026-03-09T00:03:00.129732099Z","hd":{"ts_event":"2026-03-09T00:00:00.000000000Z","rtype":160,"publisher_id":101,"instrument_id":442},"action":"A","side":"A","price":"1.153200000","size":20,"channel_id":23,"order_id":"1773014562391096283","flags":128,"ts_in_delta":2634,"sequence":61463,"symbol":"FCEU SI 20260316 PS"})";
+
+// Line 4 — Cancel (C)
+static constexpr const char *kCancelLine =
+    R"({"ts_recv":"2026-03-09T00:03:01.430638368Z","hd":{"ts_event":"2026-03-09T00:03:01.430619997Z","rtype":160,"publisher_id":101,"instrument_id":442},"action":"C","side":"A","price":"1.153200000","size":20,"channel_id":23,"order_id":"1773014562391096283","flags":128,"ts_in_delta":1201,"sequence":61595,"symbol":"FCEU SI 20260316 PS"})";
+
+// Line 5 — Trade (T), seller aggressor
+static constexpr const char *kTradeLine =
+    R"({"ts_recv":"2026-03-09T07:45:01.735130301Z","hd":{"ts_event":"2026-03-09T07:45:01.731911761Z","rtype":160,"publisher_id":101,"instrument_id":442},"action":"T","side":"A","price":"1.156100000","size":18,"channel_id":23,"order_id":"1773042301735051569","flags":0,"ts_in_delta":1304,"sequence":1570115,"symbol":"FCEU SI 20260316 PS"})";
+
+// Line 6 — Fill (F), resting buy filled
+static constexpr const char *kFillLine =
+    R"({"ts_recv":"2026-03-09T07:45:01.735130301Z","hd":{"ts_event":"2026-03-09T07:45:01.731911761Z","rtype":160,"publisher_id":101,"instrument_id":442},"action":"F","side":"B","price":"1.156100000","size":18,"channel_id":23,"order_id":"10996414336265404691","flags":0,"ts_in_delta":1304,"sequence":1570115,"symbol":"FCEU SI 20260316 PS"})";
+
+// Line 7 — Modify (M)
+static constexpr const char *kModifyLine =
+    R"({"ts_recv":"2026-03-09T13:51:44.824178477Z","hd":{"ts_event":"2026-03-09T13:51:44.824161033Z","rtype":160,"publisher_id":101,"instrument_id":442},"action":"M","side":"A","price":"1.158050000","size":20,"channel_id":23,"order_id":"1773064304823766933","flags":128,"ts_in_delta":1374,"sequence":4205894,"symbol":"FCEU SI 20260316 PS"})";
+
+// Line 8 — Options record (different instrument, small price)
+static constexpr const char *kOptionsLine =
+    R"({"ts_recv":"2026-03-09T07:52:41.368148840Z","hd":{"ts_event":"2026-03-09T07:52:41.367824437Z","rtype":160,"publisher_id":101,"instrument_id":34513},"action":"A","side":"B","price":"0.021200000","size":20,"channel_id":79,"order_id":"10996414798222631105","flags":0,"ts_in_delta":2365,"sequence":52012,"symbol":"EUCO SI 20260710 PS EU P 1.1650 0"})";
+
+// Invalid lines
+static constexpr const char *kEmptyLine = "";
+static constexpr const char *kWhitespaceLine = "   ";
+static constexpr const char *kNotJson = "this is not json at all";
+static constexpr const char *kBrokenJson =
+    R"({"ts_recv":"2026-03-09T00:03:00.129732099Z","hd":)";
+static constexpr const char *kMissingAction =
+    R"({"ts_recv":"2026-03-09T00:03:00.129732099Z","hd":{"ts_event":"2026-03-09T00:00:00.000000000Z","rtype":160,"publisher_id":101,"instrument_id":442},"side":"B","price":"1.152800000","size":20,"channel_id":23,"order_id":"123","flags":0,"ts_in_delta":0,"sequence":0,"symbol":"TEST"})";
+
+// ── Helper ──────────────────────────────────────────────────────────────
+// Writes lines into a temp file, one per line (NDJSON).
+static void writeMockFile(const std::filesystem::path &path,
+                          const std::vector<const char *> &lines) {
+  std::ofstream ofs(path);
+  for (const auto *line : lines) {
+    ofs << line << "\n";
+  }
+}
+
+// ── parseLine tests ─────────────────────────────────────────────────────
+
+TEST_CASE("parseLine — Clear action with null price", "[MarketDataParser]") {
+  MarketDataEvent evt;
+  REQUIRE(MarketDataParser::parseLine(kClearLine, evt));
+
+  CHECK(evt.action == Action::Clear);
+  CHECK(evt.side == Side::None);
+  CHECK(evt.size == Approx(0.0));
+  CHECK(evt.orderId == 0);
+  CHECK(evt.instrumentId == 442);
+  CHECK(evt.channelId == 23);
+  CHECK(evt.publisherId == 101);
+  CHECK(evt.rtype == 160);
+  CHECK(evt.flags == 8);
+  CHECK(evt.tsInDelta == 0);
+  CHECK(evt.sequence == 0);
+  CHECK(evt.symbol == "FCEU SI 20260316 PS");
+}
+
+TEST_CASE("parseLine — Add buy", "[MarketDataParser]") {
+  MarketDataEvent evt;
+  REQUIRE(MarketDataParser::parseLine(kAddBuyLine, evt));
+
+  CHECK(evt.action == Action::Add);
+  CHECK(evt.side == Side::Buy);
+  CHECK(evt.price == Approx(1.152800000));
+  CHECK(evt.size == Approx(20.0));
+  CHECK(evt.orderId == 10996386599372464268ULL);
+  CHECK(evt.flags == 0);
+  CHECK(evt.tsInDelta == 2634);
+  CHECK(evt.sequence == 61463);
+}
+
+TEST_CASE("parseLine — Add sell (ask side)", "[MarketDataParser]") {
+  MarketDataEvent evt;
+  REQUIRE(MarketDataParser::parseLine(kAddSellLine, evt));
+
+  CHECK(evt.action == Action::Add);
+  CHECK(evt.side == Side::Sell);
+  CHECK(evt.price == Approx(1.153200000));
+  CHECK(evt.flags == 128);
+  CHECK(evt.orderId == 1773014562391096283ULL);
+}
+
+TEST_CASE("parseLine — Cancel", "[MarketDataParser]") {
+  MarketDataEvent evt;
+  REQUIRE(MarketDataParser::parseLine(kCancelLine, evt));
+
+  CHECK(evt.action == Action::Cancel);
+  CHECK(evt.side == Side::Sell);
+  CHECK(evt.price == Approx(1.153200000));
+  CHECK(evt.sequence == 61595);
+}
+
+TEST_CASE("parseLine — Trade", "[MarketDataParser]") {
+  MarketDataEvent evt;
+  REQUIRE(MarketDataParser::parseLine(kTradeLine, evt));
+
+  CHECK(evt.action == Action::Trade);
+  CHECK(evt.side == Side::Sell); // aggressor was seller
+  CHECK(evt.price == Approx(1.156100000));
+  CHECK(evt.size == Approx(18.0));
+}
+
+TEST_CASE("parseLine — Fill", "[MarketDataParser]") {
+  MarketDataEvent evt;
+  REQUIRE(MarketDataParser::parseLine(kFillLine, evt));
+
+  CHECK(evt.action == Action::Fill);
+  CHECK(evt.side == Side::Buy); // resting buy was filled
+  CHECK(evt.price == Approx(1.156100000));
+  CHECK(evt.size == Approx(18.0));
+}
+
+TEST_CASE("parseLine — Modify", "[MarketDataParser]") {
+  MarketDataEvent evt;
+  REQUIRE(MarketDataParser::parseLine(kModifyLine, evt));
+
+  CHECK(evt.action == Action::Modify);
+  CHECK(evt.price == Approx(1.158050000));
+  CHECK(evt.sequence == 4205894);
+}
+
+TEST_CASE("parseLine — Options record (small price)", "[MarketDataParser]") {
+  MarketDataEvent evt;
+  REQUIRE(MarketDataParser::parseLine(kOptionsLine, evt));
+
+  CHECK(evt.price == Approx(0.021200000));
+  CHECK(evt.instrumentId == 34513);
+  CHECK(evt.channelId == 79);
+  CHECK(evt.symbol == "EUCO SI 20260710 PS EU P 1.1650 0");
+}
+
+TEST_CASE("parseLine — rejects empty line", "[MarketDataParser]") {
+  MarketDataEvent evt;
+  CHECK_FALSE(MarketDataParser::parseLine(kEmptyLine, evt));
+}
+
+TEST_CASE("parseLine — rejects whitespace-only line", "[MarketDataParser]") {
+  MarketDataEvent evt;
+  CHECK_FALSE(MarketDataParser::parseLine(kWhitespaceLine, evt));
+}
+
+TEST_CASE("parseLine — rejects non-JSON", "[MarketDataParser]") {
+  MarketDataEvent evt;
+  CHECK_FALSE(MarketDataParser::parseLine(kNotJson, evt));
+}
+
+TEST_CASE("parseLine — rejects truncated JSON", "[MarketDataParser]") {
+  MarketDataEvent evt;
+  CHECK_FALSE(MarketDataParser::parseLine(kBrokenJson, evt));
+}
+
+TEST_CASE("parseLine — rejects JSON missing required field",
+          "[MarketDataParser]") {
+  MarketDataEvent evt;
+  CHECK_FALSE(MarketDataParser::parseLine(kMissingAction, evt));
+}
+
+// ── parseFile tests ─────────────────────────────────────────────────────
+
+TEST_CASE("parseFile — counts only valid lines", "[MarketDataParser]") {
+  TempFile tmp("test_mixed.mbo.json");
+  writeMockFile(tmp.getPath(), {
+                                   kClearLine,   // valid  (1)
+                                   kAddBuyLine,  // valid  (2)
+                                   kEmptyLine,   // skip
+                                   kNotJson,     // skip
+                                   kTradeLine,   // valid  (3)
+                                   kBrokenJson,  // skip
+                                   kFillLine,    // valid  (4)
+                                   kModifyLine,  // valid  (5)
+                                   kOptionsLine, // valid  (6)
+                                   kAddSellLine, // valid  (7)
+                                   kCancelLine,  // valid  (8)
+                               });
+
+  MarketDataParser parser;
+  std::vector<MarketDataEvent> events;
+  std::size_t count =
+      parser.parseFile(tmp.getPath().string(),
+                       [&](const MarketDataEvent &e) { events.push_back(e); });
+
+  CHECK(count == 8);
+  CHECK(events.size() == 8);
+}
+
+TEST_CASE("parseFile — empty file yields zero events", "[MarketDataParser]") {
+  TempFile tmp("test_empty.mbo.json");
+  writeMockFile(tmp.getPath(), {});
+
+  MarketDataParser parser;
+  std::size_t count =
+      parser.parseFile(tmp.getPath().string(), [](const MarketDataEvent &) {});
+
+  CHECK(count == 0);
+}
+
+TEST_CASE("parseFile — all-invalid file yields zero events",
+          "[MarketDataParser]") {
+  TempFile tmp("test_all_invalid.mbo.json");
+  writeMockFile(tmp.getPath(), {
+                                   kEmptyLine,
+                                   kNotJson,
+                                   kBrokenJson,
+                                   kWhitespaceLine,
+                               });
+
+  MarketDataParser parser;
+  std::size_t count =
+      parser.parseFile(tmp.getPath().string(), [](const MarketDataEvent &) {});
+
+  CHECK(count == 0);
+}
+
+TEST_CASE("parseFile — events arrive in file order", "[MarketDataParser]") {
+  TempFile tmp("test_order.mbo.json");
+  // Clear comes first (ts 00:03:00), then Trade (ts 07:45:01)
+  writeMockFile(tmp.getPath(), {kClearLine, kTradeLine});
+
+  MarketDataParser parser;
+  std::vector<Action> actions;
+  parser.parseFile(tmp.getPath().string(), [&](const MarketDataEvent &e) {
+    actions.push_back(e.action);
+  });
+
+  REQUIRE(actions.size() == 2);
+  CHECK(actions[0] == Action::Clear);
+  CHECK(actions[1] == Action::Trade);
+}


### PR DESCRIPTION
Reads Databento L3 market-by-order (MBO) NDJSON files from Eurex (XEUR.EOBI dataset) and parses them into structured `MarketDataEvent` objects.                                               
                                                                                                                                                                                              
- **`MarketDataEvent`** (`src/common/MarketDataEvent.hpp`) — struct representing a single L3 order book event: timestamps, action (Add/Modify/Cancel/Clear/Trade/Fill), side, price, si       
         +ze, order ID, instrument ID, symbol, flags, etc. Includes stream operators for printing.                                                                                                      
- **`MarketDataParser`** (`src/main/ingestion/`) — parses NDJSON files line-by-line using nlohmann/json. Supports a callback-based API so the consumer is decoupled from parsing.             
- **`main.cpp`** — takes a single daily NDJSON file path as a command-line argument, processes all events, and prints the first 10, last 10, and a summary (total count, first/last tim       
         +estamp).                                                                                                                                                                                      
- **18 unit tests** (`test/MarketDataParserTest.cpp`) — covers all 7 action types, invalid/malformed input, file-level parsing with a mock NDJSON file.                                       
                                                                                                                                                                                              
### Dependencies                                                                                                                                                                              
                                                                                                                                                                                              
- [Catch2 v3](https://github.com/catchorg/Catch2) — C++ test framework                                                                                                                        
- [nlohmann/json v3.11.3](https://github.com/nlohmann/json) — JSON parsing                                                                                                                                                                                                                                                                                                                  

Both are fetched automatically during the CMake build.                                                                                                                                        
