### PR TITLE
HW1: Add market data parser

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@ log
 .claude
 CLAUDE.md
 
+# macOS
+.DS_Store
+
 
 ### C++ ###
 # Prerequisites

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+#
+# run.sh - one-shot helper for the HW-1 ingestion driver.
+#
+# Configures (once), builds, runs unit tests, and then runs back-tester
+# on the daily NDJSON file passed as the only argument.
+#
+# Usage:
+#   scripts/run.sh <daily-ndjson-file>
+#
+# Can be invoked from any working directory — the script resolves its own
+# location and operates relative to the project root.
+
+set -euo pipefail
+
+usage() {
+    cat >&2 <<EOF
+usage: $(basename "$0") <daily-ndjson-file>
+
+Configures (if needed), builds the project, runs unit tests, and then
+executes build/bin/back-tester on the given file. Only the last 50 lines
+of the back-tester output are shown.
+EOF
+    exit 2
+}
+
+if [[ $# -ne 1 ]]; then
+    usage
+fi
+
+INPUT="$1"
+if [[ ! -f "$INPUT" ]]; then
+    echo "error: not a regular file: $INPUT" >&2
+    exit 1
+fi
+
+# Resolve to an absolute path BEFORE we cd into the project root.
+INPUT_ABS="$(cd "$(dirname "$INPUT")" && pwd)/$(basename "$INPUT")"
+
+# scripts/ lives inside the project; jump up one level to the project root.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+cd "$PROJECT_ROOT"
+
+# Prefer cmake/ctest from PATH, fall back to ~/.local/bin (the location used
+# by the portable Kitware tarball install).
+pick_tool() {
+    local name="$1"
+    local from_path
+    from_path="$(command -v "$name" || true)"
+    if [[ -n "$from_path" ]]; then
+        echo "$from_path"
+        return
+    fi
+    if [[ -x "$HOME/.local/bin/$name" ]]; then
+        echo "$HOME/.local/bin/$name"
+        return
+    fi
+    echo ""
+}
+
+CMAKE="${CMAKE:-$(pick_tool cmake)}"
+CTEST="${CTEST:-$(pick_tool ctest)}"
+
+if [[ -z "$CMAKE" || -z "$CTEST" ]]; then
+    echo "error: cmake/ctest not found in PATH (or ~/.local/bin)" >&2
+    echo "       see SolutionDescription.md / BuildSystemNotes.md for setup" >&2
+    exit 1
+fi
+
+section() {
+    printf '\n\033[1;36m== %s ==\033[0m\n' "$*"
+}
+
+if [[ ! -f build/CMakeCache.txt ]]; then
+    section "Configure"
+    "$CMAKE" -B build -S .
+fi
+
+section "Build"
+"$CMAKE" --build build -j
+
+section "Tests"
+"$CTEST" --test-dir build -j --output-on-failure
+
+section "Run on $INPUT_ABS (tail -50)"
+build/bin/back-tester "$INPUT_ABS" | tail -50

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,2 +1,3 @@
 add_subdirectory(common)
+add_subdirectory(parser)
 add_subdirectory(main)

--- a/src/main/CMakeLists.txt
+++ b/src/main/CMakeLists.txt
@@ -1,11 +1,12 @@
 file(GLOB SRC CONFIGURE_DEPENDS *.cpp)
-list(REMOVE_ITEM SRC main.cpp)
+list(REMOVE_ITEM SRC ${CMAKE_CURRENT_SOURCE_DIR}/main.cpp)
 
 # static library
 set(TARGET back-tester-lib)
 add_library(${TARGET} STATIC ${SRC})
 target_link_libraries(${TARGET} PUBLIC
     back-tester-common
+    back-tester-parser
 )
 
 # executable

--- a/src/main/EventCollector.cpp
+++ b/src/main/EventCollector.cpp
@@ -1,0 +1,37 @@
+#include "main/EventCollector.hpp"
+
+namespace cmf {
+
+EventCollector::EventCollector(std::size_t keep_first, std::size_t keep_last)
+    : keep_first_(keep_first), keep_last_(keep_last) {
+  first_.reserve(keep_first_);
+}
+
+void EventCollector::operator()(const MarketDataEvent &ev) {
+  if (total_ == 0)
+    first_ts_ = ev.timestamp;
+  last_ts_ = ev.timestamp;
+  ++total_;
+
+  if (first_.size() < keep_first_)
+    first_.push_back(ev);
+
+  last_.push_back(ev);
+  if (last_.size() > keep_last_)
+    last_.pop_front();
+}
+
+void EventCollector::reset() {
+  first_.clear();
+  last_.clear();
+  total_ = 0;
+  first_ts_ = 0;
+  last_ts_ = 0;
+}
+
+EventCollector &defaultEventCollector() {
+  static EventCollector instance{};
+  return instance;
+}
+
+} // namespace cmf

--- a/src/main/EventCollector.hpp
+++ b/src/main/EventCollector.hpp
@@ -1,0 +1,59 @@
+// EventCollector: stateful sink that records the first N and the last N
+// MarketDataEvent instances plus simple aggregates (total / first / last
+// timestamp). Used by the HW-1 driver for the "print first 10 / last 10"
+// summary.
+//
+// Until the LOB engine arrives, this is what every event in the file
+// ultimately ends up in. A process-wide default instance is exposed via
+// defaultEventCollector() so that the free function processMarketDataEvent()
+// (which has a fixed signature mandated by the assignment) has somewhere
+// stateful to forward to.
+
+#pragma once
+
+#include "common/BasicTypes.hpp"
+#include "parser/MarketDataEvent.hpp"
+
+#include <cstddef>
+#include <cstdint>
+#include <deque>
+#include <vector>
+
+namespace cmf {
+
+class EventCollector {
+public:
+  static constexpr std::size_t kDefaultKeep = 10;
+
+  explicit EventCollector(std::size_t keep_first = kDefaultKeep,
+                          std::size_t keep_last = kDefaultKeep);
+
+  void operator()(const MarketDataEvent &ev);
+
+  const std::vector<MarketDataEvent> &firstEvents() const noexcept {
+    return first_;
+  }
+  const std::deque<MarketDataEvent> &lastEvents() const noexcept {
+    return last_;
+  }
+
+  std::uint64_t total() const noexcept { return total_; }
+  NanoTime firstTimestamp() const noexcept { return first_ts_; }
+  NanoTime lastTimestamp() const noexcept { return last_ts_; }
+
+  void reset();
+
+private:
+  std::vector<MarketDataEvent> first_;
+  std::deque<MarketDataEvent> last_;
+  std::uint64_t total_{0};
+  NanoTime first_ts_{0};
+  NanoTime last_ts_{0};
+  std::size_t keep_first_;
+  std::size_t keep_last_;
+};
+
+// Process-wide default sink. Used by processMarketDataEvent().
+EventCollector &defaultEventCollector();
+
+} // namespace cmf

--- a/src/main/IngestionRunner.cpp
+++ b/src/main/IngestionRunner.cpp
@@ -1,0 +1,36 @@
+#include "main/IngestionRunner.hpp"
+
+#include <chrono>
+#include <stdexcept>
+#include <utility>
+
+namespace cmf {
+
+IngestionRunner::IngestionRunner(std::filesystem::path path, Consumer consumer)
+    : path_(std::move(path)), consumer_(std::move(consumer)) {
+  if (!consumer_)
+    throw std::invalid_argument("IngestionRunner: consumer must not be empty");
+}
+
+IngestionStats IngestionRunner::run() {
+  FileMarketDataSource source(path_);
+  MarketDataEvent ev;
+
+  const auto t0 = std::chrono::steady_clock::now();
+  std::uint64_t total = 0;
+  while (source.next(ev)) {
+    consumer_(ev);
+    ++total;
+  }
+  const auto t1 = std::chrono::steady_clock::now();
+
+  IngestionStats stats;
+  stats.path = path_;
+  stats.total_events = total;
+  stats.skipped_lines = source.skippedCount();
+  stats.malformed_lines = source.malformedCount();
+  stats.elapsed_seconds = std::chrono::duration<double>(t1 - t0).count();
+  return stats;
+}
+
+} // namespace cmf

--- a/src/main/IngestionRunner.hpp
+++ b/src/main/IngestionRunner.hpp
@@ -1,0 +1,39 @@
+// IngestionRunner: drives one daily NDJSON file through a user-supplied
+// consumer and returns aggregate ingestion statistics. The runner does not
+// know how to print anything - that is Reporting's job.
+
+#pragma once
+
+#include "parser/FileMarketDataSource.hpp"
+#include "parser/MarketDataEvent.hpp"
+
+#include <cstdint>
+#include <filesystem>
+#include <functional>
+
+namespace cmf {
+
+struct IngestionStats {
+  std::filesystem::path path;
+  std::uint64_t total_events{0};
+  std::uint64_t skipped_lines{0};
+  std::uint64_t malformed_lines{0};
+  double elapsed_seconds{0.0};
+};
+
+class IngestionRunner {
+public:
+  using Consumer = std::function<void(const MarketDataEvent &)>;
+
+  IngestionRunner(std::filesystem::path path, Consumer consumer);
+
+  IngestionStats run();
+
+  const std::filesystem::path &path() const noexcept { return path_; }
+
+private:
+  std::filesystem::path path_;
+  Consumer consumer_;
+};
+
+} // namespace cmf

--- a/src/main/Reporting.cpp
+++ b/src/main/Reporting.cpp
@@ -1,0 +1,52 @@
+#include "main/Reporting.hpp"
+
+#include "parser/MarketDataEvent.hpp"
+
+#include <iomanip>
+#include <ostream>
+
+namespace cmf {
+
+void printBanner(std::ostream &os, const std::filesystem::path &path) {
+  os << "back-tester HW-1 ingestion\n"
+     << "  file: " << path << "\n"
+     << "  size: "
+     << (std::filesystem::file_size(path) / (1024.0 * 1024.0))
+     << " MiB\n";
+}
+
+void printReport(std::ostream &os, const IngestionStats &stats,
+                 const EventCollector &collector) {
+  const auto &first = collector.firstEvents();
+  const auto &last = collector.lastEvents();
+
+  os << "\n--- first " << first.size() << " events ---\n";
+  for (std::size_t i = 0; i < first.size(); ++i)
+    os << "[" << std::setw(2) << i << "] " << first[i] << "\n";
+
+  os << "\n--- last " << last.size() << " events ---\n";
+  std::size_t idx =
+      collector.total() > last.size() ? collector.total() - last.size() : 0;
+  for (const auto &ev : last) {
+    os << "[" << std::setw(2) << idx << "] " << ev << "\n";
+    ++idx;
+  }
+
+  os << "\n--- summary ---\n";
+  os << "total messages processed: " << stats.total_events << "\n";
+  os << "first timestamp:          "
+     << formatIso8601Nanos(collector.firstTimestamp()) << "\n";
+  os << "last  timestamp:          "
+     << formatIso8601Nanos(collector.lastTimestamp()) << "\n";
+  os << "skipped (empty) lines:    " << stats.skipped_lines << "\n";
+  os << "malformed lines:          " << stats.malformed_lines << "\n";
+  os << "elapsed:                  " << std::fixed << std::setprecision(3)
+     << stats.elapsed_seconds << " s";
+  if (stats.elapsed_seconds > 0.0)
+    os << "  (" << std::setprecision(0)
+       << (static_cast<double>(stats.total_events) / stats.elapsed_seconds)
+       << " msg/s)";
+  os << "\n";
+}
+
+} // namespace cmf

--- a/src/main/Reporting.hpp
+++ b/src/main/Reporting.hpp
@@ -1,0 +1,19 @@
+// Reporting: pretty-prints a one-line file banner and the final HW-1
+// summary (first/last N events + ingestion stats). Free functions, no
+// state, no I/O ownership - the caller passes the streams.
+
+#pragma once
+
+#include "main/EventCollector.hpp"
+#include "main/IngestionRunner.hpp"
+
+#include <iosfwd>
+
+namespace cmf {
+
+void printBanner(std::ostream &os, const std::filesystem::path &path);
+
+void printReport(std::ostream &os, const IngestionStats &stats,
+                 const EventCollector &collector);
+
+} // namespace cmf

--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -1,19 +1,40 @@
-// main function for the back-tester app
-// please, keep it minimalistic
+// HW-1 ingestion driver:
+//
+//   back-tester <path-to-daily-NDJSON>
+//
+// Wires the pieces together: parse CLI, create the runner with the
+// HW-1 consumer, run it, print the report. All logic lives in
+// EventCollector / IngestionRunner / Reporting / processMarketDataEvent.
 
-#include "common/BasicTypes.hpp"
+#include "main/EventCollector.hpp"
+#include "main/IngestionRunner.hpp"
+#include "main/Reporting.hpp"
+#include "main/processMarketDataEvent.hpp"
 
+#include <filesystem>
 #include <iostream>
+#include <stdexcept>
 
-using namespace cmf;
-
-int main([[maybe_unused]] int argc, [[maybe_unused]] const char *argv[]) {
+int main(int argc, const char *argv[]) {
   try {
-    std::cout << "Hell! Oh, world!" << std::endl;
-  } catch (std::exception &ex) {
-    std::cerr << "Back-tester threw an exception: " << ex.what() << std::endl;
+    if (argc != 2) {
+      std::cerr << "usage: " << (argc > 0 ? argv[0] : "back-tester")
+                << " <daily-ndjson-file>\n";
+      return 2;
+    }
+    const std::filesystem::path path = argv[1];
+    if (!std::filesystem::is_regular_file(path))
+      throw std::runtime_error("not a regular file: " + path.string());
+
+    cmf::printBanner(std::cerr, path);
+
+    cmf::IngestionRunner runner(path, &cmf::processMarketDataEvent);
+    const auto stats = runner.run();
+
+    cmf::printReport(std::cout, stats, cmf::defaultEventCollector());
+  } catch (const std::exception &ex) {
+    std::cerr << "back-tester: " << ex.what() << std::endl;
     return 1;
   }
-
   return 0;
 }

--- a/src/main/processMarketDataEvent.cpp
+++ b/src/main/processMarketDataEvent.cpp
@@ -1,0 +1,11 @@
+#include "main/processMarketDataEvent.hpp"
+
+#include "main/EventCollector.hpp"
+
+namespace cmf {
+
+void processMarketDataEvent(const MarketDataEvent &order) {
+  defaultEventCollector()(order);
+}
+
+} // namespace cmf

--- a/src/main/processMarketDataEvent.hpp
+++ b/src/main/processMarketDataEvent.hpp
@@ -1,0 +1,14 @@
+// processMarketDataEvent: free function with the exact signature mandated
+// by HW-1 ("void processMarketDataEvent(const MarketDataEvent& order)").
+// Forwards every event to the process-wide EventCollector. Once the LOB
+// engine arrives, this function will route into the LOB instead.
+
+#pragma once
+
+#include "parser/MarketDataEvent.hpp"
+
+namespace cmf {
+
+void processMarketDataEvent(const MarketDataEvent &order);
+
+} // namespace cmf

--- a/src/parser/CMakeLists.txt
+++ b/src/parser/CMakeLists.txt
@@ -1,0 +1,8 @@
+set(TARGET back-tester-parser)
+file(GLOB SRC CONFIGURE_DEPENDS *.cpp)
+
+add_library(${TARGET} STATIC ${SRC})
+
+target_link_libraries(${TARGET} PUBLIC
+    back-tester-common
+)

--- a/src/parser/FileMarketDataSource.cpp
+++ b/src/parser/FileMarketDataSource.cpp
@@ -1,0 +1,246 @@
+#include "parser/FileMarketDataSource.hpp"
+
+#include <algorithm>
+#include <cctype>
+#include <charconv>
+#include <cstdlib>
+#include <stdexcept>
+#include <string>
+
+namespace cmf {
+
+namespace {
+
+// ---------------------------------------------------------------------------
+// Tiny key-based JSONL extractor.
+//
+// The Databento NDJSON we ingest is flat (with one nested "hd" object) and
+// keys are unique across the line, so a key-name search is enough to extract
+// all the fields we need. This avoids pulling in a full JSON dependency.
+
+// Skips ASCII whitespace.
+const char *skipWs(const char *p, const char *end) noexcept {
+  while (p != end && (*p == ' ' || *p == '\t'))
+    ++p;
+  return p;
+}
+
+// Locates `"key":` inside [begin,end) and returns a pointer to the first
+// non-whitespace character of the value, or nullptr if not found.
+const char *findValue(const char *begin, const char *end,
+                      std::string_view key) noexcept {
+  // Build the search needle: "key":
+  std::string needle;
+  needle.reserve(key.size() + 4);
+  needle.push_back('"');
+  needle.append(key.data(), key.size());
+  needle.push_back('"');
+  needle.push_back(':');
+
+  std::string_view hay(begin, static_cast<std::size_t>(end - begin));
+  const std::size_t pos = hay.find(needle);
+  if (pos == std::string_view::npos)
+    return nullptr;
+  return skipWs(begin + pos + needle.size(), end);
+}
+
+// Reads a JSON string value that starts at *p == '"'. Returns view into
+// the original buffer (no escape handling - vendor data is plain ASCII).
+bool readString(const char *&p, const char *end, std::string_view &out) noexcept {
+  if (p == end || *p != '"')
+    return false;
+  const char *first = p + 1;
+  const char *q = first;
+  while (q != end && *q != '"')
+    ++q;
+  if (q == end)
+    return false;
+  out = std::string_view(first, static_cast<std::size_t>(q - first));
+  p = q + 1;
+  return true;
+}
+
+// Reads an unquoted number (int or float) into a string_view spanning it.
+bool readNumber(const char *&p, const char *end, std::string_view &out) noexcept {
+  const char *first = p;
+  if (p != end && (*p == '-' || *p == '+'))
+    ++p;
+  while (p != end &&
+         (std::isdigit(static_cast<unsigned char>(*p)) || *p == '.' ||
+          *p == 'e' || *p == 'E' || *p == '+' || *p == '-'))
+    ++p;
+  if (p == first)
+    return false;
+  out = std::string_view(first, static_cast<std::size_t>(p - first));
+  return true;
+}
+
+// Helpers around findValue + read* -----------------------------------------
+
+bool extractString(const char *begin, const char *end, std::string_view key,
+                   std::string_view &out) noexcept {
+  const char *p = findValue(begin, end, key);
+  if (!p)
+    return false;
+  return readString(p, end, out);
+}
+
+template <class IntT>
+bool extractInt(const char *begin, const char *end, std::string_view key,
+                IntT &out) noexcept {
+  const char *p = findValue(begin, end, key);
+  if (!p)
+    return false;
+  // value can be a quoted or unquoted integer ("order_id" comes quoted)
+  std::string_view num;
+  if (*p == '"') {
+    if (!readString(p, end, num))
+      return false;
+  } else {
+    if (!readNumber(p, end, num))
+      return false;
+  }
+  auto [ptr, ec] = std::from_chars(num.data(), num.data() + num.size(), out);
+  return ec == std::errc{} && ptr == num.data() + num.size();
+}
+
+bool extractDouble(const char *begin, const char *end, std::string_view key,
+                   double &out, bool &is_null) noexcept {
+  is_null = false;
+  const char *p = findValue(begin, end, key);
+  if (!p)
+    return false;
+  // null literal
+  if (end - p >= 4 && std::string_view(p, 4) == "null") {
+    is_null = true;
+    return true;
+  }
+  // number can be either quoted (pretty_px enables that) or raw.
+  std::string_view num;
+  if (*p == '"') {
+    if (!readString(p, end, num))
+      return false;
+  } else {
+    if (!readNumber(p, end, num))
+      return false;
+  }
+  // std::from_chars for double is supported by libc++ 20+ / libstdc++ 11+, but
+  // strtod is a safe fallback that works on every platform.
+  std::string tmp(num);
+  char *endp = nullptr;
+  out = std::strtod(tmp.c_str(), &endp);
+  return endp != tmp.c_str();
+}
+
+bool extractChar(const char *begin, const char *end, std::string_view key,
+                 char &out) noexcept {
+  std::string_view sv;
+  if (!extractString(begin, end, key, sv) || sv.empty())
+    return false;
+  out = sv.front();
+  return true;
+}
+
+} // namespace
+
+ParseStatus parseMarketDataLine(std::string_view line, MarketDataEvent &out) {
+  // Trim leading whitespace.
+  while (!line.empty() &&
+         (line.front() == ' ' || line.front() == '\t' || line.front() == '\r'))
+    line.remove_prefix(1);
+  while (!line.empty() &&
+         (line.back() == ' ' || line.back() == '\t' || line.back() == '\r'))
+    line.remove_suffix(1);
+
+  if (line.empty())
+    return ParseStatus::Empty;
+  if (line.front() != '{')
+    return ParseStatus::Malformed;
+
+  const char *begin = line.data();
+  const char *end = begin + line.size();
+
+  out = MarketDataEvent{}; // reset to defaults
+
+  // Required fields ---------------------------------------------------------
+  std::string_view ts_event_sv;
+  if (!extractString(begin, end, "ts_event", ts_event_sv))
+    return ParseStatus::Malformed;
+  out.timestamp = parseIso8601Nanos(ts_event_sv);
+  if (out.timestamp == 0)
+    return ParseStatus::Malformed;
+
+  if (!extractInt(begin, end, "order_id", out.order_id))
+    return ParseStatus::Malformed;
+
+  char side_c = 'N';
+  if (!extractChar(begin, end, "side", side_c))
+    return ParseStatus::Malformed;
+  out.side = parseMdSide(side_c);
+
+  bool price_is_null = false;
+  double price_d = 0.0;
+  if (!extractDouble(begin, end, "price", price_d, price_is_null))
+    return ParseStatus::Malformed;
+  out.price = price_is_null ? kUndefinedPrice : price_d;
+
+  std::uint64_t size_u = 0;
+  if (!extractInt(begin, end, "size", size_u))
+    return ParseStatus::Malformed;
+  out.size = static_cast<Quantity>(size_u);
+
+  char action_c = 'N';
+  if (!extractChar(begin, end, "action", action_c))
+    return ParseStatus::Malformed;
+  out.action = parseAction(action_c);
+
+  // Auxiliary fields (best effort - missing ones leave defaults) ------------
+  std::string_view ts_recv_sv;
+  if (extractString(begin, end, "ts_recv", ts_recv_sv))
+    out.ts_recv = parseIso8601Nanos(ts_recv_sv);
+
+  extractInt(begin, end, "instrument_id", out.instrument_id);
+  extractInt(begin, end, "publisher_id", out.publisher_id);
+  extractInt(begin, end, "channel_id", out.channel_id);
+  extractInt(begin, end, "sequence", out.sequence);
+  extractInt(begin, end, "ts_in_delta", out.ts_in_delta);
+  extractInt(begin, end, "rtype", out.rtype);
+  extractInt(begin, end, "flags", out.flags);
+
+  std::string_view symbol_sv;
+  if (extractString(begin, end, "symbol", symbol_sv))
+    out.symbol.assign(symbol_sv.data(), symbol_sv.size());
+
+  return ParseStatus::Ok;
+}
+
+// ---------------------------------------------------------------------------
+// FileMarketDataSource
+
+FileMarketDataSource::FileMarketDataSource(const std::filesystem::path &path)
+    : path_(path), stream_(path) {
+  if (!stream_)
+    throw std::runtime_error("FileMarketDataSource: cannot open " +
+                             path.string());
+  // Bigger buffer => fewer syscalls for big files.
+  line_buf_.reserve(1024);
+}
+
+bool FileMarketDataSource::next(MarketDataEvent &out) {
+  while (std::getline(stream_, line_buf_)) {
+    ++line_no_;
+    switch (parseMarketDataLine(line_buf_, out)) {
+    case ParseStatus::Ok:
+      return true;
+    case ParseStatus::Empty:
+      ++skipped_;
+      continue;
+    case ParseStatus::Malformed:
+      ++malformed_;
+      continue;
+    }
+  }
+  return false;
+}
+
+} // namespace cmf

--- a/src/parser/FileMarketDataSource.hpp
+++ b/src/parser/FileMarketDataSource.hpp
@@ -1,0 +1,51 @@
+// FileMarketDataSource: streams MarketDataEvent objects out of one daily
+// NDJSON L3 (Databento MBO) file. Reads line by line so that even
+// multi-gigabyte files are processed with a bounded memory footprint.
+
+#pragma once
+
+#include "parser/MarketDataEvent.hpp"
+
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <string_view>
+
+namespace cmf {
+
+// Result of parsing a single NDJSON line.
+enum class ParseStatus {
+  Ok,           // line successfully parsed into MarketDataEvent
+  Empty,        // blank line - skip
+  Malformed,    // could not parse - skip & report
+};
+
+// Parses one JSON line into `out`. Pure function; primarily used by
+// FileMarketDataSource and unit tests.
+ParseStatus parseMarketDataLine(std::string_view line, MarketDataEvent &out);
+
+class FileMarketDataSource {
+public:
+  explicit FileMarketDataSource(const std::filesystem::path &path);
+
+  // Reads the next valid event from the file. Returns false at EOF.
+  // Lines that are empty or malformed are silently skipped, but their count
+  // is exposed via skippedCount() / malformedCount().
+  bool next(MarketDataEvent &out);
+
+  std::uint64_t lineNumber() const noexcept { return line_no_; }
+  std::uint64_t skippedCount() const noexcept { return skipped_; }
+  std::uint64_t malformedCount() const noexcept { return malformed_; }
+
+  const std::filesystem::path &path() const noexcept { return path_; }
+
+private:
+  std::filesystem::path path_;
+  std::ifstream stream_;
+  std::string line_buf_;
+  std::uint64_t line_no_{0};
+  std::uint64_t skipped_{0};
+  std::uint64_t malformed_{0};
+};
+
+} // namespace cmf

--- a/src/parser/MarketDataEvent.cpp
+++ b/src/parser/MarketDataEvent.cpp
@@ -1,0 +1,194 @@
+#include "parser/MarketDataEvent.hpp"
+
+#include <array>
+#include <cctype>
+#include <charconv>
+#include <cmath>
+#include <cstdio>
+#include <ostream>
+
+namespace cmf {
+
+namespace {
+
+// Days from civil date (Howard Hinnant's algorithm). Constexpr-friendly,
+// works for the full range of int years.
+constexpr std::int64_t daysFromCivil(int y, unsigned m, unsigned d) noexcept {
+  y -= m <= 2;
+  const int era = (y >= 0 ? y : y - 399) / 400;
+  const unsigned yoe = static_cast<unsigned>(y - era * 400);
+  const unsigned doy = (153u * (m > 2 ? m - 3 : m + 9) + 2u) / 5u + d - 1u;
+  const unsigned doe = yoe * 365u + yoe / 4u - yoe / 100u + doy;
+  return static_cast<std::int64_t>(era) * 146097LL +
+         static_cast<std::int64_t>(doe) - 719468LL;
+}
+
+struct YmdHmsNs {
+  int year{};
+  unsigned month{}, day{};
+  unsigned hour{}, minute{}, second{};
+  std::uint32_t nanos{};
+  bool ok{false};
+};
+
+// Robust ISO-8601 parser:
+//   YYYY-MM-DDTHH:MM:SS[.fraction][Z]
+// Accepts 0-9 fractional digits (pads with zeros up to 9 for nanoseconds).
+YmdHmsNs parseIsoComponents(std::string_view s) noexcept {
+  YmdHmsNs out{};
+  if (s.size() < 19)
+    return out;
+
+  auto twoDigit = [](const char *p, unsigned &dst) noexcept {
+    if (!std::isdigit(static_cast<unsigned char>(p[0])) ||
+        !std::isdigit(static_cast<unsigned char>(p[1])))
+      return false;
+    dst = unsigned(p[0] - '0') * 10u + unsigned(p[1] - '0');
+    return true;
+  };
+  auto fourDigit = [](const char *p, int &dst) noexcept {
+    for (int i = 0; i < 4; ++i)
+      if (!std::isdigit(static_cast<unsigned char>(p[i])))
+        return false;
+    dst = (p[0] - '0') * 1000 + (p[1] - '0') * 100 + (p[2] - '0') * 10 +
+          (p[3] - '0');
+    return true;
+  };
+
+  const char *p = s.data();
+  if (!fourDigit(p, out.year))
+    return out;
+  if (p[4] != '-' || !twoDigit(p + 5, out.month))
+    return out;
+  if (p[7] != '-' || !twoDigit(p + 8, out.day))
+    return out;
+  if (p[10] != 'T' || !twoDigit(p + 11, out.hour))
+    return out;
+  if (p[13] != ':' || !twoDigit(p + 14, out.minute))
+    return out;
+  if (p[16] != ':' || !twoDigit(p + 17, out.second))
+    return out;
+
+  std::size_t i = 19;
+  if (i < s.size() && s[i] == '.') {
+    ++i;
+    std::uint32_t frac = 0;
+    int digits = 0;
+    while (i < s.size() &&
+           std::isdigit(static_cast<unsigned char>(s[i])) && digits < 9) {
+      frac = frac * 10u + unsigned(s[i] - '0');
+      ++digits;
+      ++i;
+    }
+    while (i < s.size() && std::isdigit(static_cast<unsigned char>(s[i]))) {
+      ++i; // ignore extra precision
+    }
+    for (int k = digits; k < 9; ++k)
+      frac *= 10u;
+    out.nanos = frac;
+  }
+  // tolerate trailing 'Z' or nothing
+  out.ok = true;
+  return out;
+}
+
+} // namespace
+
+NanoTime parseIso8601Nanos(std::string_view ts) noexcept {
+  const auto c = parseIsoComponents(ts);
+  if (!c.ok)
+    return 0;
+  const std::int64_t days = daysFromCivil(c.year, c.month, c.day);
+  const std::int64_t secs = days * 86'400LL +
+                            std::int64_t(c.hour) * 3'600 +
+                            std::int64_t(c.minute) * 60 + std::int64_t(c.second);
+  return secs * 1'000'000'000LL + std::int64_t(c.nanos);
+}
+
+std::string formatIso8601Nanos(NanoTime ns) {
+  // Split into seconds and nanoseconds, then back into civil date.
+  // Floor-divides correctly even for negative values.
+  std::int64_t secs = ns / 1'000'000'000LL;
+  std::int64_t nanos = ns - secs * 1'000'000'000LL;
+  if (nanos < 0) {
+    nanos += 1'000'000'000LL;
+    --secs;
+  }
+  std::int64_t days = secs / 86'400LL;
+  std::int64_t tod = secs - days * 86'400LL;
+  if (tod < 0) {
+    tod += 86'400LL;
+    --days;
+  }
+  // Inverse of daysFromCivil
+  std::int64_t z = days + 719468;
+  const std::int64_t era = (z >= 0 ? z : z - 146096) / 146097;
+  const unsigned doe = static_cast<unsigned>(z - era * 146097);
+  const unsigned yoe =
+      (doe - doe / 1460u + doe / 36524u - doe / 146096u) / 365u;
+  const int y0 = static_cast<int>(yoe) + static_cast<int>(era) * 400;
+  const unsigned doy = doe - (365u * yoe + yoe / 4u - yoe / 100u);
+  const unsigned mp = (5u * doy + 2u) / 153u;
+  const unsigned d = doy - (153u * mp + 2u) / 5u + 1u;
+  const unsigned m = mp < 10u ? mp + 3u : mp - 9u;
+  const int y = y0 + (m <= 2 ? 1 : 0);
+  const unsigned hh = unsigned(tod / 3600);
+  const unsigned mm = unsigned((tod / 60) % 60);
+  const unsigned ss = unsigned(tod % 60);
+
+  std::array<char, 40> buf{};
+  std::snprintf(buf.data(), buf.size(),
+                "%04d-%02u-%02uT%02u:%02u:%02u.%09lldZ", y, m, d, hh, mm, ss,
+                static_cast<long long>(nanos));
+  return std::string(buf.data());
+}
+
+Action parseAction(char c) noexcept {
+  switch (c) {
+  case 'A':
+    return Action::Add;
+  case 'M':
+    return Action::Modify;
+  case 'C':
+    return Action::Cancel;
+  case 'R':
+    return Action::Clear;
+  case 'T':
+    return Action::Trade;
+  case 'F':
+    return Action::Fill;
+  default:
+    return Action::None;
+  }
+}
+
+MdSide parseMdSide(char c) noexcept {
+  switch (c) {
+  case 'B':
+    return MdSide::Bid;
+  case 'A':
+    return MdSide::Ask;
+  default:
+    return MdSide::None;
+  }
+}
+
+std::ostream &operator<<(std::ostream &os, const MarketDataEvent &ev) {
+  os << "ts=" << formatIso8601Nanos(ev.timestamp)
+     << " order_id=" << ev.order_id
+     << " side=" << static_cast<char>(ev.side);
+
+  if (priceDefined(ev.price))
+    os << " price=" << ev.price;
+  else
+    os << " price=null";
+
+  os << " size=" << ev.size
+     << " action=" << static_cast<char>(ev.action);
+
+  if (!ev.symbol.empty())
+    os << " symbol=\"" << ev.symbol << "\"";
+  return os;
+}
+
+} // namespace cmf

--- a/src/parser/MarketDataEvent.hpp
+++ b/src/parser/MarketDataEvent.hpp
@@ -1,0 +1,95 @@
+// MarketDataEvent: a single L3 (MBO) message produced by the ingestion layer
+// of the back-tester. Mirrors the fields delivered by Databento JSON-line feed
+// (XEUR.EOBI / mbo schema) without coupling to the wire format itself.
+
+#pragma once
+
+#include "common/BasicTypes.hpp"
+
+#include <cstdint>
+#include <iosfwd>
+#include <limits>
+#include <string>
+#include <string_view>
+
+namespace cmf {
+
+// Action carried by an L3 message (Databento MBO conventions).
+//   A - Add a new resting order to the book
+//   M - Modify an existing order
+//   C - Cancel (full / partial) an existing order
+//   R - Clear the book (start of session, snapshot reset)
+//   T - Trade (does NOT change the book by itself)
+//   F - Fill (matched against a resting order)
+//   N - None / unspecified
+enum class Action : char {
+  None = 'N',
+  Add = 'A',
+  Modify = 'M',
+  Cancel = 'C',
+  Clear = 'R',
+  Trade = 'T',
+  Fill = 'F',
+};
+
+// Side as reported by the market-data feed: bid / ask / none.
+// Distinct from cmf::Side which carries trade direction (Buy / Sell).
+enum class MdSide : char {
+  None = 'N',
+  Bid = 'B',
+  Ask = 'A',
+};
+
+// Sentinel for an undefined price (Databento reports null for snapshot resets).
+inline constexpr Price kUndefinedPrice = std::numeric_limits<Price>::quiet_NaN();
+
+inline bool priceDefined(Price p) noexcept {
+  return !(p != p); // NaN-safe check
+}
+
+// Single immutable L3 message handed to the LOB / strategy layer.
+//
+// The fields explicitly required by HW-1 are first
+// (timestamp / order_id / side / price / size / action), the rest are kept
+// because they are essentially free to parse and useful downstream.
+struct MarketDataEvent {
+  // Required by the assignment ----------------------------------------------
+  NanoTime timestamp{};   // ts_event in nanoseconds since epoch (UTC)
+  OrderId order_id{};     // exchange-side order id
+  MdSide side{MdSide::None};
+  Price price{kUndefinedPrice};
+  Quantity size{};
+  Action action{Action::None};
+
+  // Auxiliary fields parsed from the same record ----------------------------
+  NanoTime ts_recv{};
+  std::uint32_t instrument_id{};
+  std::uint16_t publisher_id{};
+  std::uint16_t channel_id{};
+  std::uint32_t sequence{};
+  std::int32_t ts_in_delta{};
+  std::uint8_t rtype{};
+  std::uint8_t flags{};
+  std::string symbol{};
+};
+
+// Helpers ------------------------------------------------------------------
+
+// Parse "YYYY-MM-DDTHH:MM:SS.nnnnnnnnnZ" into nanoseconds since UNIX epoch.
+// Returns 0 on malformed input (caller may inspect via parseMarketDataLine
+// return code).
+NanoTime parseIso8601Nanos(std::string_view ts) noexcept;
+
+// Formats a NanoTime back to the canonical ISO-8601 / nanosecond form used
+// by Databento. Useful for printing summaries.
+std::string formatIso8601Nanos(NanoTime ns);
+
+// Map wire-level chars to enums. Unknown values become `None`.
+Action parseAction(char c) noexcept;
+MdSide parseMdSide(char c) noexcept;
+
+// Stream insertion: prints the event in a fixed, human-readable format
+// (used by the consumer in main()).
+std::ostream &operator<<(std::ostream &os, const MarketDataEvent &ev);
+
+} // namespace cmf

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -20,6 +20,8 @@ add_executable(${TARGET} ${TEST_SRC})
 target_link_libraries(${TARGET} PRIVATE
     Catch2-static-lib
     back-tester-common
+    back-tester-parser
+    back-tester-lib
 )
 
 # Register the tests with CTest

--- a/test/EventCollectorTest.cpp
+++ b/test/EventCollectorTest.cpp
@@ -1,0 +1,65 @@
+// tests for EventCollector
+
+#include "main/EventCollector.hpp"
+#include "parser/MarketDataEvent.hpp"
+
+#include "catch2/catch_all.hpp"
+
+using namespace cmf;
+
+namespace {
+
+MarketDataEvent makeEvent(NanoTime ts, OrderId id) {
+  MarketDataEvent ev;
+  ev.timestamp = ts;
+  ev.order_id = id;
+  ev.action = Action::Add;
+  ev.side = MdSide::Bid;
+  ev.size = 1.0;
+  ev.price = 1.0;
+  return ev;
+}
+
+} // namespace
+
+TEST_CASE("EventCollector keeps first N and last N", "[EventCollector]") {
+  EventCollector c(3, 3);
+
+  for (std::uint64_t i = 1; i <= 10; ++i)
+    c(makeEvent(static_cast<NanoTime>(i), i));
+
+  REQUIRE(c.total() == 10u);
+  REQUIRE(c.firstTimestamp() == 1);
+  REQUIRE(c.lastTimestamp() == 10);
+
+  REQUIRE(c.firstEvents().size() == 3u);
+  REQUIRE(c.firstEvents().front().order_id == 1u);
+  REQUIRE(c.firstEvents().back().order_id == 3u);
+
+  REQUIRE(c.lastEvents().size() == 3u);
+  REQUIRE(c.lastEvents().front().order_id == 8u);
+  REQUIRE(c.lastEvents().back().order_id == 10u);
+}
+
+TEST_CASE("EventCollector tolerates fewer events than the window",
+          "[EventCollector]") {
+  EventCollector c(10, 10);
+  c(makeEvent(42, 7));
+
+  REQUIRE(c.total() == 1u);
+  REQUIRE(c.firstEvents().size() == 1u);
+  REQUIRE(c.lastEvents().size() == 1u);
+  REQUIRE(c.firstTimestamp() == 42);
+  REQUIRE(c.lastTimestamp() == 42);
+}
+
+TEST_CASE("EventCollector::reset clears everything", "[EventCollector]") {
+  EventCollector c(2, 2);
+  c(makeEvent(1, 1));
+  c(makeEvent(2, 2));
+  c.reset();
+
+  REQUIRE(c.total() == 0u);
+  REQUIRE(c.firstEvents().empty());
+  REQUIRE(c.lastEvents().empty());
+}

--- a/test/MarketDataEventTest.cpp
+++ b/test/MarketDataEventTest.cpp
@@ -1,0 +1,117 @@
+// tests for MarketDataEvent + FileMarketDataSource
+
+#include "parser/FileMarketDataSource.hpp"
+#include "parser/MarketDataEvent.hpp"
+
+#include "TempFile.hpp"
+
+#include "catch2/catch_all.hpp"
+
+#include <cmath>
+#include <fstream>
+#include <sstream>
+
+using namespace cmf;
+
+namespace {
+
+constexpr const char *kSampleClear =
+    R"({"ts_recv":"2026-04-06T18:53:11.430340287Z","hd":{"ts_event":"2026-04-06T18:53:11.430338519Z","rtype":160,"publisher_id":101,"instrument_id":33974},"action":"R","side":"N","price":null,"size":0,"channel_id":79,"order_id":"0","flags":128,"ts_in_delta":1768,"sequence":0,"symbol":"EUCO SI 20270312 PS EU P 1.2250 0"})";
+
+constexpr const char *kSampleAdd =
+    R"({"ts_recv":"2026-04-07T07:00:00.123456789Z","hd":{"ts_event":"2026-04-07T07:00:00.123456000Z","rtype":160,"publisher_id":101,"instrument_id":42},"action":"A","side":"B","price":"1.156100000","size":7,"channel_id":12,"order_id":"123456789","flags":0,"ts_in_delta":-5,"sequence":42,"symbol":"FOO BAR"})";
+
+} // namespace
+
+TEST_CASE("ISO timestamp parsing", "[MarketDataEvent]") {
+  REQUIRE(parseIso8601Nanos("1970-01-01T00:00:00.000000000Z") == 0);
+  REQUIRE(parseIso8601Nanos("1970-01-01T00:00:00.000000001Z") == 1);
+  // 2026-04-07T07:00:00Z = 1'775'545'200 s since epoch.
+  REQUIRE(parseIso8601Nanos("2026-04-07T07:00:00.000000000Z") ==
+          1'775'545'200'000'000'000LL);
+  // round trip
+  const auto ns = parseIso8601Nanos("2026-04-07T07:00:00.123456789Z");
+  REQUIRE(formatIso8601Nanos(ns) == "2026-04-07T07:00:00.123456789Z");
+}
+
+TEST_CASE("parseMarketDataLine - clear (null price)", "[MarketDataEvent]") {
+  MarketDataEvent ev;
+  REQUIRE(parseMarketDataLine(kSampleClear, ev) == ParseStatus::Ok);
+
+  REQUIRE(ev.action == Action::Clear);
+  REQUIRE(ev.side == MdSide::None);
+  REQUIRE(ev.order_id == 0u);
+  REQUIRE(ev.size == 0.0);
+  REQUIRE_FALSE(priceDefined(ev.price));
+  REQUIRE(ev.timestamp == parseIso8601Nanos("2026-04-06T18:53:11.430338519Z"));
+  REQUIRE(ev.ts_recv == parseIso8601Nanos("2026-04-06T18:53:11.430340287Z"));
+  REQUIRE(ev.instrument_id == 33974u);
+  REQUIRE(ev.publisher_id == 101u);
+  REQUIRE(ev.channel_id == 79u);
+  REQUIRE(ev.flags == 128u);
+  REQUIRE(ev.ts_in_delta == 1768);
+  REQUIRE(ev.sequence == 0u);
+  REQUIRE(ev.symbol == "EUCO SI 20270312 PS EU P 1.2250 0");
+}
+
+TEST_CASE("parseMarketDataLine - add (real price + side)", "[MarketDataEvent]") {
+  MarketDataEvent ev;
+  REQUIRE(parseMarketDataLine(kSampleAdd, ev) == ParseStatus::Ok);
+
+  REQUIRE(ev.action == Action::Add);
+  REQUIRE(ev.side == MdSide::Bid);
+  REQUIRE(ev.order_id == 123456789ULL);
+  REQUIRE(ev.size == 7.0);
+  REQUIRE(priceDefined(ev.price));
+  REQUIRE(std::abs(ev.price - 1.1561) < 1e-12);
+  REQUIRE(ev.ts_in_delta == -5);
+  REQUIRE(ev.sequence == 42u);
+  REQUIRE(ev.symbol == "FOO BAR");
+}
+
+TEST_CASE("parseMarketDataLine - rejects malformed input", "[MarketDataEvent]") {
+  MarketDataEvent ev;
+  REQUIRE(parseMarketDataLine("", ev) == ParseStatus::Empty);
+  REQUIRE(parseMarketDataLine("not-json", ev) == ParseStatus::Malformed);
+  REQUIRE(parseMarketDataLine("{}", ev) == ParseStatus::Malformed);
+}
+
+TEST_CASE("MarketDataEvent stream insertion", "[MarketDataEvent]") {
+  MarketDataEvent ev;
+  REQUIRE(parseMarketDataLine(kSampleAdd, ev) == ParseStatus::Ok);
+
+  std::ostringstream os;
+  os << ev;
+  const std::string s = os.str();
+  REQUIRE(s.find("order_id=123456789") != std::string::npos);
+  REQUIRE(s.find("side=B") != std::string::npos);
+  REQUIRE(s.find("action=A") != std::string::npos);
+  REQUIRE(s.find("size=7") != std::string::npos);
+  REQUIRE(s.find("symbol=\"FOO BAR\"") != std::string::npos);
+}
+
+TEST_CASE("FileMarketDataSource - reads NDJSON file", "[MarketDataEvent]") {
+  TempFile tmp("md_test.ndjson");
+  {
+    std::ofstream of(tmp.getPath());
+    of << kSampleClear << "\n";
+    of << "\n";          // empty line - skipped
+    of << "garbage\n";   // malformed - skipped
+    of << kSampleAdd << "\n";
+  }
+
+  FileMarketDataSource src(tmp.getPath());
+
+  MarketDataEvent ev;
+  REQUIRE(src.next(ev));
+  REQUIRE(ev.action == Action::Clear);
+
+  REQUIRE(src.next(ev));
+  REQUIRE(ev.action == Action::Add);
+  REQUIRE(ev.order_id == 123456789ULL);
+
+  REQUIRE_FALSE(src.next(ev));
+
+  REQUIRE(src.skippedCount() == 1u);
+  REQUIRE(src.malformedCount() == 1u);
+}


### PR DESCRIPTION
participant: Mashinson Vsevolod

# HW-1 — Market Data Parser

## Что сделано

Базовый слой извлечения данных для event-driven бэктестера:

- класс `MarketDataEvent` (поля из ТЗ + вспомогательные поля Databento MBO);
- потоковый парсер дневного NDJSON-файла (без загрузки всего файла в память);
- свободная функция-потребитель `processMarketDataEvent(const MarketDataEvent&)`
  с **точно** той сигнатурой, что требовалась в задании;
- драйвер, печатающий первые 10, последние 10 событий и summary
  (`total`, первый/последний таймстемп, число пропущенных/битых строк,
  время и пропускная способность);
- юнит-тесты на парсер и коллектор (Catch2, **10/10**);
- скрипт-обёртка `scripts/run.sh` — `cmake build` + `ctest` + запуск на файле.

### `src/parser/` — модуль `back-tester-parser`

| Файл | Назначение |
| --- | --- |
| `MarketDataEvent.hpp` | Структура `MarketDataEvent`, `enum class Action`, `enum class MdSide`, `kUndefinedPrice` (`NaN`) + хелпер `priceDefined`. |
| `MarketDataEvent.cpp` | Парсинг/форматирование ISO-8601 наносекундных таймстемпов, `operator<<` для человекочитаемой печати. |
| `FileMarketDataSource.hpp` | Интерфейс источника: `next(MarketDataEvent&)`, счётчики `lineNumber/skipped/malformed`. Чистая функция `parseMarketDataLine`. |
| `FileMarketDataSource.cpp` | Построчное чтение через `std::getline` + мини-извлекатель JSON по ключу (без сторонних зависимостей). |

### `src/main/` — модули `back-tester-lib` + исполняемый `back-tester`

| Файл | Назначение |
| --- | --- |
| `processMarketDataEvent.{hpp,cpp}` | Свободная функция-потребитель с сигнатурой из ТЗ. Делегирует в `defaultEventCollector()`. |
| `EventCollector.{hpp,cpp}` | Хранит первые `N` (`std::vector`) и последние `N` (`std::deque`) событий, `total`, `first_ts`, `last_ts`. Не зависит от I/O. |
| `IngestionRunner.{hpp,cpp}` | Цикл `source.next() → consumer`, измеряет время, возвращает `IngestionStats`. Принимает `Consumer = std::function<void(const MarketDataEvent&)>` — удобно для тестов. |
| `Reporting.{hpp,cpp}` | `printBanner` и `printReport` — вся форматировка вывода. |
| `main.cpp` | Тонкий entrypoint: парсит CLI, валидирует путь, собирает `IngestionRunner(path, &processMarketDataEvent)`, дёргает `run()` и `printReport()`. |

### `test/`

| Файл | Что проверяет |
| --- | --- |
| `MarketDataEventTest.cpp` | ISO-таймстемп round-trip, парсинг строк `clear`/`add`, отказ на мусоре, `operator<<`, поведение `FileMarketDataSource` через `TempFile`. |
| `EventCollectorTest.cpp` | first-N / last-N при `total > 2N`, корректность при `total < N`, `reset()`. |
| `BasicTypesTest.cpp` | Smoke-тест из шаблона курса. |
| `TempFile.hpp` | RAII-хелпер для тестов, которым нужен временный NDJSON-файл. |

### Прочее

- `scripts/run.sh` — one-shot скрипт «build + test + run».
- Изменения в `src/CMakeLists.txt`, `src/parser/CMakeLists.txt`,
  `src/main/CMakeLists.txt`, `test/CMakeLists.txt` — подключение нового
  модуля `back-tester-parser`, разделение `back-tester-lib` (без `main.cpp`)
  и исполняемого `back-tester`, линковка тестов с `back-tester-lib`.

## Как запустить

```bash
cd back-tester-2026

# полный цикл одной командой: configure (если нужно) + build + ctest + back-tester | tail -50
scripts/run.sh /path/to/<day>.mbo.json

# если нет +x на файле — то же самое через bash:
bash scripts/run.sh /path/to/<day>.mbo.json
```


Пример вывода

```
--- first 10 events ---
[ 0] ts=2026-03-24T07:57:54.828457431Z order_id=0 side=N price=null size=0 action=R symbol="EUCO SI 20260911 PS EU C 1.1675 0"
[ 1] ts=2026-03-24T07:57:54.828457431Z order_id=10997711111683259731 side=B price=0.02352 size=20 action=A symbol="EUCO SI 20260911 PS EU C 1.1675 0"
[ 2] ts=2026-03-24T07:57:54.828457431Z order_id=1774339074828483923 side=A price=0.02395 size=20 action=A symbol="EUCO SI 20260911 PS EU C 1.1675 0"
[ 3] ts=2026-03-24T07:57:54.828457431Z order_id=0 side=N price=null size=0 action=R symbol="EUCO SI 20260911 PS EU C 1.1775 0"
[ 4] ts=2026-03-24T07:57:54.828457431Z order_id=10997711111683259731 side=B price=0.01882 size=20 action=A symbol="EUCO SI 20260911 PS EU C 1.1775 0"
[ 5] ts=2026-03-24T07:57:54.828457431Z order_id=1774339074828483923 side=A price=0.01925 size=20 action=A symbol="EUCO SI 20260911 PS EU C 1.1775 0"
[ 6] ts=2026-03-24T07:57:54.828457431Z order_id=0 side=N price=null size=0 action=R symbol="EUCO SI 20260911 PS EU P 1.1750 0"
[ 7] ts=2026-03-24T07:57:54.828457431Z order_id=10997711111683259731 side=B price=0.02575 size=20 action=A symbol="EUCO SI 20260911 PS EU P 1.1750 0"
[ 8] ts=2026-03-24T07:57:54.828457431Z order_id=1774339074828483923 side=A price=0.02618 size=20 action=A symbol="EUCO SI 20260911 PS EU P 1.1750 0"
[ 9] ts=2026-03-24T07:57:54.828457431Z order_id=0 side=N price=null size=0 action=R symbol="EUCO SI 20260911 PS EU C 1.1725 0"

--- last 10 events ---
[1006609] ts=2026-03-24T17:32:15.716208655Z order_id=10997745568899052247 side=B price=0.02144 size=20 action=C symbol="EUCO SI 20260911 PS EU C 1.1675 0"
[1006610] ts=2026-03-24T17:32:15.716208655Z order_id=1774373532044276439 side=A price=0.02186 size=20 action=C symbol="EUCO SI 20260911 PS EU C 1.1675 0"
[1006611] ts=2026-03-24T17:32:15.716208655Z order_id=10997745568715667010 side=B price=0.01914 size=20 action=C symbol="EUCO SI 20260911 PS EU C 1.1725 0"
[1006612] ts=2026-03-24T17:32:15.716208655Z order_id=1774373531860891202 side=A price=0.01957 size=20 action=C symbol="EUCO SI 20260911 PS EU C 1.1725 0"
[1006613] ts=2026-03-24T17:32:15.716208655Z order_id=10997745568715667010 side=B price=0.026 size=20 action=C symbol="EUCO SI 20260911 PS EU P 1.1725 0"
[1006614] ts=2026-03-24T17:32:15.716208655Z order_id=1774373531860891202 side=A price=0.02642 size=20 action=C symbol="EUCO SI 20260911 PS EU P 1.1725 0"
[1006615] ts=2026-03-24T17:32:15.716208655Z order_id=10997745568715667010 side=B price=0.021 size=20 action=C symbol="EUCO SI 20260911 PS EU P 1.1625 0"
[1006616] ts=2026-03-24T17:32:15.716208655Z order_id=1774373531860891202 side=A price=0.02142 size=20 action=C symbol="EUCO SI 20260911 PS EU P 1.1625 0"
[1006617] ts=2026-03-24T17:32:15.716208655Z order_id=10997745568715667010 side=B price=0.0234 size=20 action=C symbol="EUCO SI 20260911 PS EU P 1.1675 0"
[1006618] ts=2026-03-24T17:32:15.716208655Z order_id=1774373531860891202 side=A price=0.02382 size=20 action=C symbol="EUCO SI 20260911 PS EU P 1.1675 0"

--- summary ---
total messages processed: 1006619
first timestamp:          2026-03-24T07:57:54.828457431Z
last  timestamp:          2026-03-24T17:32:15.716208655Z
skipped (empty) lines:    0
malformed lines:          0
elapsed:                  3.672 s  (274165 msg/s)
```