### PR TITLE
Task1: Simple Data Loader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -279,3 +279,6 @@ __marimo__/
 # Ignore all local history of files
 .history
 .ionide
+
+.DS_Store
+/data

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,2 +1,3 @@
 add_subdirectory(common)
+add_subdirectory(data_ingestion)
 add_subdirectory(main)

--- a/src/data_ingestion/CMakeLists.txt
+++ b/src/data_ingestion/CMakeLists.txt
@@ -1,0 +1,9 @@
+file(GLOB_RECURSE LIB_SRC CONFIGURE_DEPENDS parsers/*.cpp)
+
+set(LIB_TARGET back-tester-data-ingestion)
+add_library(${LIB_TARGET} STATIC ${LIB_SRC})
+target_link_libraries(${LIB_TARGET} PUBLIC back-tester-common)
+
+set(EXE_TARGET simple-loader)
+add_executable(${EXE_TARGET} simple_loader_main.cpp)
+target_link_libraries(${EXE_TARGET} PRIVATE ${LIB_TARGET})

--- a/src/data_ingestion/MarketDataEvent.hpp
+++ b/src/data_ingestion/MarketDataEvent.hpp
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "common/BasicTypes.hpp"
+#include "enums.hpp"
+#include <optional>
+
+
+
+namespace cmf {
+
+struct MarketDataEvent {
+    NanoTime ts_received;
+    NanoTime ts_event;
+    
+    Price price;
+    Quantity qty;
+    
+    OrderId order_id;
+    SecurityId instrument_id;
+    MarketId market_id;
+    std::uint16_t channel_id;
+
+    action::Action action;
+    side::Side side;
+    std::uint8_t flags;
+
+    std::uint32_t sequence;
+    std::string symbol;
+
+};
+
+}

--- a/src/data_ingestion/README.md
+++ b/src/data_ingestion/README.md
@@ -1,0 +1,127 @@
+# data_ingestion
+
+Reads Databento MBO (market-by-order) NDJSON files and produces `MarketDataEvent` objects.
+
+---
+
+## Components
+
+### `MarketDataEvent` — core data struct
+
+```cpp
+struct MarketDataEvent {
+    NanoTime   ts_received;      // wall-clock time packet was received (ns since epoch)
+    NanoTime   ts_event;         // exchange timestamp of the event   (ns since epoch)
+    Price      price;            // order price (double, 0.0 when JSON price is null)
+    Quantity   qty;              // order quantity
+    OrderId    order_id;         // uint64 — quoted string in JSON ("1775088023898785831")
+    SecurityId instrument_id;   // from hd.instrument_id
+    MarketId   market_id;        // from hd.publisher_id
+    uint16_t   channel_id;
+    uint32_t   sequence;
+    uint8_t    flags;            // bitmask — see flags section below
+    Action     action;           // Add / Modify / Cancel / Clear / Trade / Fill / None
+    Side       side;             // Buy / Sell / None
+    string     symbol;
+};
+```
+
+### `enums.hpp` — typed enumerations
+
+| Enum | Values | Source field |
+|------|--------|-------------|
+| `action::Action` | Add `A`, Modify `M`, Cancel `C`, Clear `R`, Trade `T`, Fill `F`, None `N` | `"action"` |
+| `side::Side` | Buy `B`, Sell `A`, None `N` | `"side"` |
+| `flags::Flag` | bitmask — see below | `"flags"` |
+
+### Flags bitmask
+
+| Flag | Bit | Decimal | Meaning |
+|------|-----|---------|---------|
+| `F_LAST`              | 7 | 128 | Last record in event for this instrument |
+| `F_TOB`               | 6 |  64 | Top-of-book message, not individual order |
+| `F_SNAPSHOT`          | 5 |  32 | Sourced from replay / snapshot server |
+| `F_MBP`               | 4 |  16 | Aggregated price level, not individual order |
+| `F_BAD_TS_RECV`       | 3 |   8 | `ts_recv` inaccurate (clock issue / packet reorder) |
+| `F_MAYBE_BAD_BOOK`    | 2 |   4 | Unrecoverable channel gap — book state unknown |
+| `F_PUBLISHER_SPECIFIC`| 1 |   2 | Meaning depends on `publisher_id` |
+
+Multiple flags can be set simultaneously in one number (bitmask):
+
+```cpp
+// flags = 160 → F_LAST (128) + F_SNAPSHOT (32) are both set
+bool is_last = cmf::flags::has(ev.flags, cmf::flags::F_LAST);
+bool skip    = cmf::flags::should_skip(ev.flags);  // true if F_BAD_TS_RECV or F_MAYBE_BAD_BOOK
+```
+
+### `JSONParser` — line parser
+
+Parses one NDJSON line into a `MarketDataEvent`. All parsing is pointer-based (zero heap allocation except `symbol`). No external JSON libraries used.
+
+**Expected JSON format (Databento MBO):**
+```json
+{
+  "ts_recv": "2026-04-02T00:00:23.898795059Z",
+  "hd": {
+    "ts_event":     "2026-04-02T00:00:23.898773987Z",
+    "publisher_id": 101,
+    "instrument_id": 436
+  },
+  "action":     "A",
+  "side":       "B",
+  "price":      "1.162900000",
+  "size":       20,
+  "channel_id": 23,
+  "order_id":   "1775088023898785831",
+  "flags":      128,
+  "sequence":   124519,
+  "symbol":     "FCEU SI 20260615 PS"
+}
+```
+
+Notes:
+- `price` may be `null` → stored as `0.0`
+- `price` and `order_id` are quoted strings in Databento output
+- `ts_event` and `instrument_id` are nested inside `"hd"`
+- Timestamps are parsed to nanoseconds since Unix epoch without any heap allocation
+
+### `SimpleLoader` — file reader
+
+Reads an NDJSON file line-by-line and calls a consumer for each parsed event.
+
+```cpp
+cmf::SimpleLoader loader("xeur-eobi-20260402.mbo.json");
+
+loader.load([](const cmf::MarketDataEvent& ev) {
+    if (cmf::flags::should_skip(ev.flags)) return;
+    // process ev
+});
+```
+
+Malformed lines are silently skipped.
+
+---
+
+## Build
+
+```bash
+cmake -S . -B build
+cmake --build build --target simple-loader
+```
+
+## Run
+
+```bash
+./build/bin/simple-loader <ndjson-file>
+```
+
+Prints the first and last 10 events and a summary:
+
+```
+--- Summary ---
+Total messages : 577366
+First ts       : 2026-04-02T06:38:37.527868463Z
+Last  ts       : 2026-04-02T16:20:01.994301309Z
+Elapsed (s)    : 3.10
+Msg/sec        : 186143
+```

--- a/src/data_ingestion/SimpleLoader.hpp
+++ b/src/data_ingestion/SimpleLoader.hpp
@@ -1,0 +1,39 @@
+#pragma once
+
+#include "MarketDataEvent.hpp"
+#include "parsers/JSONParser.hpp"
+#include <fstream>
+#include <stdexcept>
+#include <string>
+
+namespace cmf {
+
+class SimpleLoader {
+public:
+    explicit SimpleLoader(const std::string& path) : path_(path) {}
+
+    // Reads the file line-by-line (NDJSON).
+    // For each parseable line, creates a MarketDataEvent and calls process().
+    // Malformed lines are silently skipped.
+    template<typename Consumer>
+    void load(Consumer&& process) {
+        std::ifstream file(path_);
+        if (!file.is_open())
+            throw std::runtime_error("Cannot open file: " + path_);
+
+        parser::MDParser& base = parser_;
+        std::string line;
+        while (std::getline(file, line)) {
+            if (line.empty()) continue;
+            try {
+                process(base.parse_line(line));
+            } catch (...) {}
+        }
+    }
+
+private:
+    std::string path_;
+    parser::JSONParser parser_;
+};
+
+} // namespace cmf

--- a/src/data_ingestion/enums.hpp
+++ b/src/data_ingestion/enums.hpp
@@ -1,0 +1,84 @@
+#pragma once
+#include <stdexcept>
+#include <string>
+
+namespace cmf::action {
+enum class Action : char {
+    Add    = 'A', // Insert a new order into the book
+    Modify = 'M', // Change price and/or size
+    Cancel = 'C', // Fully or partially cancel
+    Clear  = 'R', // Remove all resting orders
+    Trade  = 'T', // Aggressing order traded (no book change)
+    Fill   = 'F', // Resting order filled (no book change)
+    None   = 'N'  // No action
+};
+
+inline Action from_char(char c) {
+    switch (c) {
+        case 'A': return Action::Add;
+        case 'M': return Action::Modify;
+        case 'C': return Action::Cancel;
+        case 'R': return Action::Clear;
+        case 'T': return Action::Trade;
+        case 'F': return Action::Fill;
+        case 'N': return Action::None;
+        default: throw std::invalid_argument("Unknown action");
+    }
+}
+
+inline std::string to_string(Action a) {
+    switch (a) {
+        case Action::Add:    return "Add";
+        case Action::Modify: return "Modify";
+        case Action::Cancel: return "Cancel";
+        case Action::Clear:  return "Clear";
+        case Action::Trade:  return "Trade";
+        case Action::Fill:   return "Fill";
+        case Action::None:   return "None";
+        default:             return "Unknown";
+    }
+}
+}
+
+namespace cmf::flags {
+    enum Flag : std::uint8_t {
+        F_LAST              = 1 << 7,  // last record in event for this instrument_id
+        F_TOB               = 1 << 6,  // top-of-book message, not individual order
+        F_SNAPSHOT          = 1 << 5,  // sourced from replay / snapshot server
+        F_MBP               = 1 << 4,  // aggregated price level, not individual order
+        F_BAD_TS_RECV       = 1 << 3,  // ts_recv inaccurate (clock issue / reordering)
+        F_MAYBE_BAD_BOOK    = 1 << 2,  // unrecoverable gap — book state unknown
+        F_PUBLISHER_SPECIFIC= 1 << 1,  // meaning depends on publisher_id
+    };
+
+    inline bool has(std::uint8_t f, Flag flag) { return f & flag; }
+
+    // Returns true when the row should be discarded:
+    //   F_BAD_TS_RECV    — timestamp is unreliable
+    //   F_MAYBE_BAD_BOOK — channel gap, book is in unknown state
+    inline bool should_skip(std::uint8_t f) {
+        return has(f, F_BAD_TS_RECV) || has(f, F_MAYBE_BAD_BOOK);
+    }
+}
+
+namespace cmf::side {
+    enum class Side : signed short { None = 0, Buy = 1, Sell = -1 };
+
+    inline Side from_char(char c) {
+        switch (c) {
+            case 'A': return Side::Sell;
+            case 'B': return Side::Buy;
+            case 'N': return Side::None;
+            default: throw std::invalid_argument("Unknown Side");
+        }
+    }
+
+    inline const char* to_string(Side s) {
+        switch (s) {
+            case Side::Sell: return "Sell";
+            case Side::Buy:  return "Buy";
+            case Side::None: return "None";
+            default:         return "Unknown";
+        }
+    }
+}

--- a/src/data_ingestion/parsers/JSONParser.cpp
+++ b/src/data_ingestion/parsers/JSONParser.cpp
@@ -1,0 +1,163 @@
+#include "JSONParser.hpp"
+#include <cctype>
+#include <cstdlib>
+#include <cstring>
+#include <ctime>
+
+namespace cmf::parser::json {
+
+// Returns pointer to the start of a value for the given key, or nullptr.
+static const char* find_key(const char* p, const char* end,
+                             const char* key, size_t klen) {
+    for (; p + klen + 1 < end; ++p) {
+        if (p[0] == '"'
+            && std::memcmp(p + 1, key, klen) == 0
+            && p[klen + 1] == '"') {
+            const char* after = p + klen + 2;
+            if (after < end && *after == ':') {
+                ++after;
+                while (after < end && *after == ' ') ++after;
+                return after;
+            }
+        }
+    }
+    return nullptr;
+}
+
+// Returns a view into the original buffer — no copies.
+// Strips outer quotes for strings; returns empty view for null.
+static std::string_view read_value(const char* p, const char* end) {
+    if (!p || p >= end) return {};
+    if (*p == '"') {
+        const char* s = p + 1;
+        const char* e = s;
+        while (e < end && *e != '"') ++e;
+        return {s, static_cast<size_t>(e - s)};
+    }
+    if (*p == 'n') return {};  // null
+    const char* s = p;
+    while (p < end && *p != ',' && *p != '}' && *p != ' ') ++p;
+    return {s, static_cast<size_t>(p - s)};
+}
+
+template<typename T>
+static T parse_uint(const char* p, const char* end) {
+    T v = 0;
+    while (p < end && *p >= '0' && *p <= '9')
+        v = static_cast<T>(v * 10 + (*p++ - '0'));
+    return v;
+}
+
+static double parse_double(const char* p, const char* end) {
+    if (p >= end) return 0.0;
+    bool neg = (*p == '-');
+    if (neg) ++p;
+    std::int64_t integer = 0;
+    while (p < end && *p >= '0' && *p <= '9')
+        integer = integer * 10 + (*p++ - '0');
+    std::int64_t frac = 0;
+    int frac_digits = 0;
+    if (p < end && *p == '.') {
+        ++p;
+        while (p < end && *p >= '0' && *p <= '9') {
+            frac = frac * 10 + (*p++ - '0');
+            ++frac_digits;
+        }
+    }
+    static constexpr double pow10[] = {
+        1, 10, 100, 1e3, 1e4, 1e5, 1e6, 1e7, 1e8, 1e9, 1e10, 1e11, 1e12
+    };
+    double result = static_cast<double>(integer)
+                  + static_cast<double>(frac) / pow10[frac_digits];
+    return neg ? -result : result;
+}
+
+
+// Parses "2026-03-09T07:52:41.368148840Z" directly from raw bytes.
+static NanoTime parse_timestamp(const char* p, size_t len) {
+    if (len < 19) return 0;
+
+    auto r2 = [](const char* s) { return (s[0] - '0') * 10 + (s[1] - '0'); };
+    auto r4 = [](const char* s) {
+        return (s[0]-'0')*1000 + (s[1]-'0')*100 + (s[2]-'0')*10 + (s[3]-'0');
+    };
+
+    std::tm t{};
+    t.tm_year = r4(p)      - 1900;
+    t.tm_mon  = r2(p +  5) - 1;
+    t.tm_mday = r2(p +  8);
+    t.tm_hour = r2(p + 11);
+    t.tm_min  = r2(p + 14);
+    t.tm_sec  = r2(p + 17);
+
+    std::int64_t nanos = 0;
+    if (len > 20 && p[19] == '.') {
+        const char* f    = p + 20;
+        const char* fend = f;
+        while (fend < p + len && *fend != 'Z') ++fend;
+        for (size_t i = 0; i < 9; ++i)
+            nanos = nanos * 10 + (f + i < fend ? f[i] - '0' : 0);
+    }
+
+    return static_cast<NanoTime>(timegm(&t)) * 1'000'000'000LL + nanos;
+}
+
+} // namespace cmf::parser::json
+
+namespace cmf::parser {
+
+MarketDataEvent JSONParser::parse_line(const std::string& line) {
+
+    const char* buf = line.data();
+    const char* end = buf + line.size();
+
+    auto get = [&](const char* key, size_t klen) {
+        return json::read_value(json::find_key(buf, end, key, klen), end);
+    };
+
+    MarketDataEvent ev{};
+
+    auto sv = get("ts_recv", 7);
+    ev.ts_received = json::parse_timestamp(sv.data(), sv.size());
+
+    sv = get("ts_event", 8);
+    ev.ts_event = json::parse_timestamp(sv.data(), sv.size());
+
+    sv = get("instrument_id", 13);
+    ev.instrument_id = json::parse_uint<SecurityId>(sv.data(), sv.data() + sv.size());
+
+    sv = get("publisher_id", 12);
+    ev.market_id = json::parse_uint<MarketId>(sv.data(), sv.data() + sv.size());
+
+    sv = get("channel_id", 10);
+    ev.channel_id = json::parse_uint<std::uint32_t>(sv.data(), sv.data() + sv.size());
+
+    sv = get("order_id", 8);
+    ev.order_id = json::parse_uint<OrderId>(sv.data(), sv.data() + sv.size());
+
+    sv = get("sequence", 8);
+    ev.sequence = json::parse_uint<std::uint32_t>(sv.data(), sv.data() + sv.size());
+
+    sv = get("flags", 5);
+    ev.flags = json::parse_uint<std::uint8_t>(sv.data(), sv.data() + sv.size());
+
+    sv = get("size", 4);
+    ev.qty = json::parse_double(sv.data(), sv.data() + sv.size());
+
+    sv = get("price", 5);
+    if (!sv.empty())
+        ev.price = json::parse_double(sv.data(), sv.data() + sv.size());
+
+    sv = get("symbol", 6);
+    ev.symbol.assign(sv.data(), sv.size());
+
+    sv = get("action", 6);
+    if (!sv.empty()) ev.action = action::from_char(sv[0]);
+
+    sv = get("side", 4);
+    if (!sv.empty()) ev.side = side::from_char(sv[0]);
+
+    return ev;
+}
+
+} // namespace cmf::parser

--- a/src/data_ingestion/parsers/JSONParser.hpp
+++ b/src/data_ingestion/parsers/JSONParser.hpp
@@ -1,0 +1,10 @@
+#pragma once
+
+#include "Parser.hpp"
+#include "data_ingestion/MarketDataEvent.hpp"
+
+namespace cmf::parser{
+    class JSONParser: public MDParser {
+        MarketDataEvent parse_line(const std::string & line) override;
+    };
+}

--- a/src/data_ingestion/parsers/Parser.hpp
+++ b/src/data_ingestion/parsers/Parser.hpp
@@ -1,0 +1,12 @@
+#pragma once
+#include "data_ingestion/MarketDataEvent.hpp"
+#include <string>
+
+namespace cmf::parser{
+class MDParser {
+    public:
+        virtual ~MDParser() = default;
+
+        virtual MarketDataEvent parse_line(const std::string & line) = 0;
+};
+}

--- a/src/data_ingestion/simple_loader_main.cpp
+++ b/src/data_ingestion/simple_loader_main.cpp
@@ -1,0 +1,73 @@
+#include "SimpleLoader.hpp"
+#include <chrono>
+#include <cstdio>
+#include <ctime>
+#include <deque>
+#include <iostream>
+
+static std::string nano_to_string(cmf::NanoTime ns) {
+    std::time_t secs = ns / 1'000'000'000LL;
+    long nanos       = ns % 1'000'000'000LL;
+    std::tm t{};
+    gmtime_r(&secs, &t);
+    char buf[48];
+    std::snprintf(buf, sizeof(buf), "%04d-%02d-%02dT%02d:%02d:%02d.%09ldZ",
+        t.tm_year + 1900, t.tm_mon + 1, t.tm_mday,
+        t.tm_hour, t.tm_min, t.tm_sec, nanos);
+    return buf;
+}
+
+static void processMarketDataEvent(const cmf::MarketDataEvent& ev) {
+    std::cout << "ts_event, nanosec=" << ev.ts_event << " ts_event, usual=" << nano_to_string(ev.ts_event) 
+              << " oid="    << ev.order_id
+              << " side="   << cmf::side::to_string(ev.side)
+              << " price="  << ev.price
+              << " size="   << ev.qty
+              << " action=" << cmf::action::to_string(ev.action)
+              << "\n";
+}
+
+int main(int argc, char* argv[]) {
+    if (argc < 2) {
+        std::cerr << "Usage: " << argv[0] << " <ndjson-file>\n";
+        return 1;
+    }
+
+    cmf::SimpleLoader loader(argv[1]);
+
+    std::uint64_t total = 0;
+    cmf::NanoTime first_ts = 0, last_ts = 0;
+    std::vector<cmf::MarketDataEvent> first10;
+    std::deque<cmf::MarketDataEvent>  last10;
+
+    const auto t_start = std::chrono::steady_clock::now();
+    loader.load([&](const cmf::MarketDataEvent& ev) {
+        if (cmf::flags::should_skip(ev.flags)) return;
+
+        ++total;
+        if (total == 1) first_ts = ev.ts_received;
+        last_ts = ev.ts_received;
+
+        if (first10.size() < 10) first10.push_back(ev);
+        last10.push_back(ev);
+        if (last10.size() > 10) last10.pop_front();
+    });
+
+    std::cout << "--- First 10 events ---\n";
+    for (const auto& ev : first10) processMarketDataEvent(ev);
+
+    std::cout << "\n--- Last 10 events ---\n";
+    for (const auto& ev : last10) processMarketDataEvent(ev);
+
+    std::cout << "\n--- Summary ---\n";
+    const double elapsed = std::chrono::duration<double>(
+        std::chrono::steady_clock::now() - t_start).count();
+
+    std::cout << "Total messages   : " << total << "\n";
+    std::cout << "First ts received: " << nano_to_string(first_ts) << "\n";
+    std::cout << "Last  ts received: " << nano_to_string(last_ts)  << "\n";
+    std::cout << "Elapsed (s)      : " << elapsed  << "\n";
+    std::cout << "Msg/sec          : " << static_cast<std::uint64_t>(total / elapsed) << "\n";
+
+    return 0;
+}


### PR DESCRIPTION
# data_ingestion

Reads Databento MBO (market-by-order) NDJSON files and produces `MarketDataEvent` objects.

---

## Components

### `MarketDataEvent` — core data struct

```cpp
struct MarketDataEvent {
    NanoTime   ts_received;      // wall-clock time packet was received (ns since epoch)
    NanoTime   ts_event;         // exchange timestamp of the event   (ns since epoch)
    Price      price;            // order price (double, 0.0 when JSON price is null)
    Quantity   qty;              // order quantity
    OrderId    order_id;         // uint64 — quoted string in JSON ("1775088023898785831")
    SecurityId instrument_id;   // from hd.instrument_id
    MarketId   market_id;        // from hd.publisher_id
    uint16_t   channel_id;
    uint32_t   sequence;
    uint8_t    flags;            // bitmask — see flags section below
    Action     action;           // Add / Modify / Cancel / Clear / Trade / Fill / None
    Side       side;             // Buy / Sell / None
    string     symbol;
};
```

### `enums.hpp` — typed enumerations

| Enum | Values | Source field |
|------|--------|-------------|
| `action::Action` | Add `A`, Modify `M`, Cancel `C`, Clear `R`, Trade `T`, Fill `F`, None `N` | `"action"` |
| `side::Side` | Buy `B`, Sell `A`, None `N` | `"side"` |
| `flags::Flag` | bitmask — see below | `"flags"` |

### Flags bitmask

| Flag | Bit | Decimal | Meaning |
|------|-----|---------|---------|
| `F_LAST`              | 7 | 128 | Last record in event for this instrument |
| `F_TOB`               | 6 |  64 | Top-of-book message, not individual order |
| `F_SNAPSHOT`          | 5 |  32 | Sourced from replay / snapshot server |
| `F_MBP`               | 4 |  16 | Aggregated price level, not individual order |
| `F_BAD_TS_RECV`       | 3 |   8 | `ts_recv` inaccurate (clock issue / packet reorder) |
| `F_MAYBE_BAD_BOOK`    | 2 |   4 | Unrecoverable channel gap — book state unknown |
| `F_PUBLISHER_SPECIFIC`| 1 |   2 | Meaning depends on `publisher_id` |

Multiple flags can be set simultaneously in one number (bitmask):

```cpp
// flags = 160 → F_LAST (128) + F_SNAPSHOT (32) are both set
bool is_last = cmf::flags::has(ev.flags, cmf::flags::F_LAST);
bool skip    = cmf::flags::should_skip(ev.flags);  // true if F_BAD_TS_RECV or F_MAYBE_BAD_BOOK
```

### `JSONParser` — line parser

Parses one NDJSON line into a `MarketDataEvent`. All parsing is pointer-based (zero heap allocation except `symbol`). No external JSON libraries used.

**Expected JSON format (Databento MBO):**
```json
{
  "ts_recv": "2026-04-02T00:00:23.898795059Z",
  "hd": {
    "ts_event":     "2026-04-02T00:00:23.898773987Z",
    "publisher_id": 101,
    "instrument_id": 436
  },
  "action":     "A",
  "side":       "B",
  "price":      "1.162900000",
  "size":       20,
  "channel_id": 23,
  "order_id":   "1775088023898785831",
  "flags":      128,
  "sequence":   124519,
  "symbol":     "FCEU SI 20260615 PS"
}
```

Notes:
- `price` may be `null` → stored as `0.0`
- `price` and `order_id` are quoted strings in Databento output
- `ts_event` and `instrument_id` are nested inside `"hd"`
- Timestamps are parsed to nanoseconds since Unix epoch without any heap allocation

### `SimpleLoader` — file reader

Reads an NDJSON file line-by-line and calls a consumer for each parsed event.

```cpp
cmf::SimpleLoader loader("xeur-eobi-20260402.mbo.json");

loader.load([](const cmf::MarketDataEvent& ev) {
    if (cmf::flags::should_skip(ev.flags)) return;
    // process ev
});
```

Malformed lines are silently skipped.

---

## Build

```bash
cmake -S . -B build
cmake --build build --target simple-loader
```

## Run

```bash
./build/bin/simple-loader <ndjson-file>
```

Prints the first and last 10 events and a summary:

```
./build/bin/simple-loader data/XEUR-20260409-HTT6HHLT6R/xeur-eobi-20260309.mbo.json

--- First 10 events ---
ts_event, nanosec=1773014400000000000 ts_event, usual=2026-03-09T00:00:00.000000000Z oid=10996386599372464268 side=Buy price=1.1528 size=20 action=Add
ts_event, nanosec=1773014400000000000 ts_event, usual=2026-03-09T00:00:00.000000000Z oid=1773014562391096283 side=Sell price=1.1532 size=20 action=Add
ts_event, nanosec=1773014581430619997 ts_event, usual=2026-03-09T00:03:01.430619997Z oid=1773014562391096283 side=Sell price=1.1532 size=20 action=Cancel
ts_event, nanosec=1773014581473439135 ts_event, usual=2026-03-09T00:03:01.473439135Z oid=1773014581473445312 side=Sell price=1.1533 size=20 action=Add
ts_event, nanosec=1773014582654272919 ts_event, usual=2026-03-09T00:03:02.654272919Z oid=1773014582654279204 side=Sell price=1.1532 size=20 action=Add
ts_event, nanosec=1773014582654295141 ts_event, usual=2026-03-09T00:03:02.654295141Z oid=1773014581473445312 side=Sell price=1.1533 size=20 action=Cancel
ts_event, nanosec=1773014587731453219 ts_event, usual=2026-03-09T00:03:07.731453219Z oid=10996386599372464268 side=Buy price=1.1528 size=20 action=Cancel
ts_event, nanosec=1773014587774943087 ts_event, usual=2026-03-09T00:03:07.774943087Z oid=10996386624629724865 side=Buy price=1.1527 size=20 action=Add
ts_event, nanosec=1773014588231167141 ts_event, usual=2026-03-09T00:03:08.231167141Z oid=1773014588231173191 side=Sell price=1.1531 size=20 action=Add
ts_event, nanosec=1773014588231219793 ts_event, usual=2026-03-09T00:03:08.231219793Z oid=1773014582654279204 side=Sell price=1.1532 size=20 action=Cancel

--- Last 10 events ---
ts_event, nanosec=1773089995689776937 ts_event, usual=2026-03-09T20:59:55.689776937Z oid=10996462032544558641 side=Buy price=1.1638 size=20 action=Add
ts_event, nanosec=1773089995689824199 ts_event, usual=2026-03-09T20:59:55.689824199Z oid=10996462025991048260 side=Buy price=1.1637 size=20 action=Cancel
ts_event, nanosec=1773089996086485681 ts_event, usual=2026-03-09T20:59:56.086485681Z oid=10996462032544558641 side=Buy price=1.1638 size=20 action=Cancel
ts_event, nanosec=1773089996088724707 ts_event, usual=2026-03-09T20:59:56.088724707Z oid=10996462025995478435 side=Buy price=1.1687 size=20 action=Cancel
ts_event, nanosec=1773089996108553315 ts_event, usual=2026-03-09T20:59:56.108553315Z oid=1773089955299847935 side=Sell price=1.1695 size=20 action=Cancel
ts_event, nanosec=1773089996129395311 ts_event, usual=2026-03-09T20:59:56.129395311Z oid=1773089996129401590 side=Sell price=1.1641 size=20 action=Add
ts_event, nanosec=1773089996129549359 ts_event, usual=2026-03-09T20:59:56.129549359Z oid=1773089995088358222 side=Sell price=1.1642 size=20 action=Cancel
ts_event, nanosec=1773089996137225481 ts_event, usual=2026-03-09T20:59:56.137225481Z oid=10996462032992007174 side=Buy price=1.1635 size=20 action=Add
ts_event, nanosec=1773089996181811195 ts_event, usual=2026-03-09T20:59:56.181811195Z oid=10996462032992007174 side=Buy price=1.1635 size=20 action=Cancel
ts_event, nanosec=1773089996181814509 ts_event, usual=2026-03-09T20:59:56.181814509Z oid=1773089996129401590 side=Sell price=1.1641 size=20 action=Cancel

--- Summary ---
Total messages   : 2232536
First ts received: 2026-03-09T00:03:00.129732099Z
Last  ts received: 2026-03-09T20:59:56.181828842Z
Elapsed (s)      : 11.8363
Msg/sec          : 188617
```
