### PR TITLE
Task 1 for backtester

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,11 @@
 .idea/
 3rdparty/*
 build
+build-*/
 log
 .claude
 CLAUDE.md
+.DS_Store
 
 
 ### C++ ###

--- a/scripts/run_benchmark.sh
+++ b/scripts/run_benchmark.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# run_benchmark.sh — benchmark runner for the back-tester Hard task.
+#
+# Runs the binary N times on the given directory and reports per-run
+# throughput plus per-strategy min/median/max aggregates.
+#
+# Usage:
+#   scripts/run_benchmark.sh <directory>
+#                            [--runs=N]
+#                            [--strategy={flat|hierarchy|both}]
+#                            [--warmup]
+#
+# Notes:
+#   * First run after boot is cold-cache; subsequent runs read from page
+#     cache. Use --warmup to discard the first (cold) run from aggregates.
+#   * Throughput is reported in messages per second (msg/s).
+
+set -euo pipefail
+
+usage() {
+    cat >&2 <<EOF
+Usage: $0 <directory> [--runs=N] [--strategy={flat|hierarchy|both}] [--warmup]
+
+  <directory>          Directory containing *.mbo.json NDJSON files.
+  --runs=N             Number of runs (default: 3).
+  --strategy=<kind>    flat | hierarchy | both (default: both).
+  --warmup             Run once before measured runs; drop it from stats.
+EOF
+    exit 1
+}
+
+[[ $# -ge 1 ]] || usage
+DIR="$1"; shift
+
+RUNS=3
+STRAT=both
+WARMUP=0
+for a in "$@"; do
+    case "$a" in
+        --runs=*)     RUNS="${a#--runs=}" ;;
+        --strategy=*) STRAT="${a#--strategy=}" ;;
+        --warmup)     WARMUP=1 ;;
+        -h|--help)    usage ;;
+        *) echo "unknown flag: $a" >&2; usage ;;
+    esac
+done
+
+case "$STRAT" in flat|hierarchy|both) ;; *) echo "bad strategy: $STRAT" >&2; exit 1;; esac
+[[ "$RUNS" =~ ^[0-9]+$ ]] || { echo "bad runs: $RUNS" >&2; exit 1; }
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+BIN="$ROOT/build/bin/back-tester"
+
+# Build if necessary.
+if [[ ! -x "$BIN" ]]; then
+    echo "[build] $BIN not found; configuring + building..." >&2
+    (cd "$ROOT" && cmake -B build -S . >/dev/null && cmake --build build -j >/dev/null)
+fi
+[[ -d "$DIR" ]] || { echo "error: directory not found: $DIR" >&2; exit 1; }
+
+TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+
+file_count=$(find -L "$DIR" -maxdepth 1 -name "*.mbo.json" | wc -l | awk '{print $1}')
+
+echo "=== back-tester benchmark ==="
+echo "Directory: $DIR"
+echo "Files:     $file_count"
+echo "Runs:      $RUNS$([[ $WARMUP -eq 1 ]] && echo ' (+1 warmup, dropped)')"
+echo "Strategy:  $STRAT"
+echo "Binary:    $BIN"
+echo
+
+if [[ $WARMUP -eq 1 ]]; then
+    echo "[warmup] prefilling page cache..."
+    "$BIN" "$DIR" --strategy="$STRAT" >/dev/null
+    echo
+fi
+
+for i in $(seq 1 "$RUNS"); do
+    log="$TMP/run_$i.log"
+    printf "[run %d/%d]\n" "$i" "$RUNS"
+    "$BIN" "$DIR" --strategy="$STRAT" > "$log"
+    grep -E "^(Flat|Hierarchy):" "$log" | sed 's/^/    /'
+done
+
+echo
+echo "=== Aggregate throughput (msg/s) ==="
+for strat in Flat Hierarchy; do
+    case "$STRAT" in
+        flat)      [[ "$strat" == "Flat"      ]] || continue ;;
+        hierarchy) [[ "$strat" == "Hierarchy" ]] || continue ;;
+    esac
+    vals=$(for i in $(seq 1 "$RUNS"); do
+        grep "^$strat:" "$TMP/run_$i.log" 2>/dev/null \
+            | sed 's/.*throughput=\([0-9]*\).*/\1/'
+    done | sort -n)
+    [[ -n "$vals" ]] || continue
+    min=$(echo "$vals" | head -1)
+    max=$(echo "$vals" | tail -1)
+    n=$(echo "$vals" | wc -l | awk '{print $1}')
+    mid=$(( (n + 1) / 2 ))
+    median=$(echo "$vals" | sed -n "${mid}p")
+    # Render with thousands separators via printf %'d (POSIX-2024; fallback OK).
+    printf "%-10s  min=%12d   median=%12d   max=%12d\n" \
+        "$strat:" "$min" "$median" "$max"
+done

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,2 +1,3 @@
 add_subdirectory(common)
+add_subdirectory(market_data)
 add_subdirectory(main)

--- a/src/main/CMakeLists.txt
+++ b/src/main/CMakeLists.txt
@@ -1,14 +1,24 @@
 file(GLOB SRC CONFIGURE_DEPENDS *.cpp)
-list(REMOVE_ITEM SRC main.cpp)
+list(REMOVE_ITEM SRC ${CMAKE_CURRENT_SOURCE_DIR}/main.cpp)
 
-# static library
-set(TARGET back-tester-lib)
-add_library(${TARGET} STATIC ${SRC})
-target_link_libraries(${TARGET} PUBLIC
-    back-tester-common
-)
+# static library for non-main sources (if any — currently empty, reserved for
+# future growth).
+if(SRC)
+    set(TARGET back-tester-lib)
+    add_library(${TARGET} STATIC ${SRC})
+    target_link_libraries(${TARGET} PUBLIC
+        back-tester-common
+        back-tester-market-data
+    )
+endif()
 
 # executable
 set(TARGET back-tester)
 add_executable(${TARGET} main.cpp)
-target_link_libraries(${TARGET} PUBLIC back-tester-lib)
+target_link_libraries(${TARGET} PUBLIC
+    back-tester-common
+    back-tester-market-data
+)
+if(TARGET back-tester-lib)
+    target_link_libraries(back-tester PUBLIC back-tester-lib)
+endif()

--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -1,19 +1,137 @@
-// main function for the back-tester app
-// please, keep it minimalistic
+// main — CLI entry point for the back-tester data-ingestion layer.
+//
+// Standard task:
+//   back-tester <path/to/file.mbo.json>
+//     Parses one NDJSON file, prints first and last 10 events and a summary.
+//
+// Hard task:
+//   back-tester <path/to/directory> [--strategy={flat|hierarchy|both}]
+//                                   [--verbose]
+//     Spawns one producer thread per *.mbo.json file in the directory,
+//     builds a k-way merger (Flat / Hierarchy / both back-to-back), dispatches
+//     the merged chronological stream through processMarketDataEvent, and
+//     prints a benchmark line (total, elapsed, throughput, fingerprint).
 
-#include "common/BasicTypes.hpp"
+#include "market_data/Consumer.hpp"
+#include "market_data/HardTask.hpp"
 
+#include <cstdlib>
+#include <cstring>
+#include <exception>
+#include <filesystem>
 #include <iostream>
+#include <string>
+#include <string_view>
+#include <vector>
 
-using namespace cmf;
+namespace {
 
-int main([[maybe_unused]] int argc, [[maybe_unused]] const char *argv[]) {
-  try {
-    std::cout << "Hell! Oh, world!" << std::endl;
-  } catch (std::exception &ex) {
-    std::cerr << "Back-tester threw an exception: " << ex.what() << std::endl;
-    return 1;
+struct CliArgs {
+  std::filesystem::path path;
+  std::string strategy = "both"; // flat | hierarchy | both
+  bool verbose = false;
+};
+
+void printUsage(const char *prog) {
+  std::cerr << "Usage:\n"
+            << "  " << prog << " <path-to-file.mbo.json>                  "
+            << "# Standard task\n"
+            << "  " << prog
+            << " <path-to-dir> [--strategy=<flat|hierarchy|both>] "
+               "[--verbose]\n"
+            << "                                                       "
+            << "# Hard task\n";
+}
+
+bool startsWith(std::string_view s, std::string_view prefix) {
+  return s.size() >= prefix.size() && s.compare(0, prefix.size(), prefix) == 0;
+}
+
+CliArgs parseArgs(int argc, const char *argv[]) {
+  CliArgs a;
+  if (argc < 2)
+    throw std::runtime_error("missing path argument");
+  a.path = argv[1];
+  for (int i = 2; i < argc; ++i) {
+    std::string_view arg = argv[i];
+    if (startsWith(arg, "--strategy=")) {
+      a.strategy = std::string(arg.substr(std::strlen("--strategy=")));
+    } else if (arg == "--verbose") {
+      a.verbose = true;
+    } else {
+      throw std::runtime_error("unknown flag: " + std::string{arg});
+    }
+  }
+  if (a.strategy != "flat" && a.strategy != "hierarchy" && a.strategy != "both")
+    throw std::runtime_error("--strategy must be flat|hierarchy|both");
+  return a;
+}
+
+int runStandard(const CliArgs &args) {
+  constexpr std::size_t kHead = 10;
+  constexpr std::size_t kTail = 10;
+  const auto s = cmf::runStandardTask(args.path, kHead, kTail, std::cout);
+  std::cout << "\nDone. Processed " << s.total << " messages.\n";
+  return EXIT_SUCCESS;
+}
+
+int runHard(const CliArgs &args) {
+  const auto files = cmf::listMboJsonFiles(args.path);
+  if (files.empty()) {
+    std::cerr << "No *.mbo.json files found in " << args.path << "\n";
+    return EXIT_FAILURE;
   }
 
-  return 0;
+  std::cout << "Discovered " << files.size() << " MBO NDJSON files in "
+            << args.path << ":\n";
+  for (const auto &f : files)
+    std::cout << "  " << f.filename().string() << "\n";
+  std::cout << "\n";
+
+  const bool do_flat = args.strategy == "flat" || args.strategy == "both";
+  const bool do_hier = args.strategy == "hierarchy" || args.strategy == "both";
+
+  cmf::BenchmarkResult flat_r, hier_r;
+  if (do_flat) {
+    flat_r = cmf::runHardTask(files, cmf::MergerKind::Flat, args.verbose);
+    cmf::printBenchmarkResult(std::cout, flat_r);
+  }
+  if (do_hier) {
+    hier_r = cmf::runHardTask(files, cmf::MergerKind::Hierarchy, args.verbose);
+    cmf::printBenchmarkResult(std::cout, hier_r);
+  }
+
+  if (do_flat && do_hier) {
+    std::cout << "\n=== Cross-check ===\n"
+              << "Total match:       "
+              << (flat_r.total == hier_r.total ? "yes" : "NO") << "\n"
+              << "Fingerprint match: "
+              << (flat_r.fingerprint == hier_r.fingerprint ? "yes" : "NO")
+              << "\n";
+    if (flat_r.total != hier_r.total ||
+        flat_r.fingerprint != hier_r.fingerprint)
+      return EXIT_FAILURE;
+  }
+  return EXIT_SUCCESS;
+}
+
+} // namespace
+
+int main(int argc, const char *argv[]) {
+  try {
+    const auto args = parseArgs(argc, argv);
+
+    std::error_code ec;
+    if (!std::filesystem::exists(args.path, ec)) {
+      std::cerr << "Path does not exist: " << args.path << "\n";
+      return EXIT_FAILURE;
+    }
+    if (std::filesystem::is_directory(args.path, ec))
+      return runHard(args);
+    return runStandard(args);
+  } catch (const std::exception &ex) {
+    std::cerr << "back-tester: fatal: " << ex.what() << "\n";
+    printUsage(argc > 0 ? argv[0] : "back-tester");
+    return EXIT_FAILURE;
+  }
 }

--- a/src/market_data/CMakeLists.txt
+++ b/src/market_data/CMakeLists.txt
@@ -1,0 +1,8 @@
+set(TARGET back-tester-market-data)
+file(GLOB SRC CONFIGURE_DEPENDS *.cpp)
+
+add_library(${TARGET} STATIC ${SRC})
+
+target_link_libraries(${TARGET} PUBLIC
+    back-tester-common
+)

--- a/src/market_data/Consumer.cpp
+++ b/src/market_data/Consumer.cpp
@@ -1,0 +1,59 @@
+#include "market_data/Consumer.hpp"
+
+#include "market_data/MmapMboSource.hpp"
+
+#include <deque>
+#include <iostream>
+#include <ostream>
+#include <vector>
+
+namespace cmf {
+
+void processMarketDataEvent(const MarketDataEvent &event) {
+  std::cout << event << '\n';
+}
+
+IngestionSummary runStandardTask(const std::filesystem::path &path,
+                                 std::size_t head_n, std::size_t tail_n,
+                                 std::ostream &out) {
+  MmapMboSource source(path);
+
+  IngestionSummary s;
+  std::vector<MarketDataEvent> head;
+  head.reserve(head_n);
+  std::deque<MarketDataEvent> tail;
+
+  MarketDataEvent e;
+  while (source.next(e)) {
+    if (s.total == 0)
+      s.first_ts = e.ts_recv;
+    s.last_ts = e.ts_recv;
+    ++s.total;
+
+    if (head.size() < head_n)
+      head.push_back(e);
+    if (tail_n > 0) {
+      tail.push_back(std::move(e));
+      if (tail.size() > tail_n)
+        tail.pop_front();
+    }
+  }
+
+  out << "=== Summary ===\n"
+      << "File:           " << path.string() << "\n"
+      << "Total messages: " << s.total << "\n"
+      << "First ts_recv:  " << s.first_ts << " ns\n"
+      << "Last  ts_recv:  " << s.last_ts << " ns\n";
+
+  out << "\n=== First " << head.size() << " events ===\n";
+  for (const auto &e : head)
+    out << e << '\n';
+
+  out << "\n=== Last " << tail.size() << " events ===\n";
+  for (const auto &e : tail)
+    out << e << '\n';
+
+  return s;
+}
+
+} // namespace cmf

--- a/src/market_data/Consumer.hpp
+++ b/src/market_data/Consumer.hpp
@@ -1,0 +1,42 @@
+// Consumer — downstream sink for MarketDataEvents.
+//
+// The free function `processMarketDataEvent` matches the signature specified
+// in task_1.md and is the eventual hand-off point to the LOB engine. For now
+// it just prints the event for verification.
+
+#pragma once
+
+#include "common/BasicTypes.hpp"
+#include "market_data/MarketDataEvent.hpp"
+
+#include <cstddef>
+#include <cstdint>
+#include <filesystem>
+#include <iosfwd>
+
+namespace cmf {
+
+// Prints the event details to stdout (via MarketDataEvent::operator<<).
+// Task-mandated signature — do not change.
+void processMarketDataEvent(const MarketDataEvent &event);
+
+// Aggregate stats collected during ingestion of one or more NDJSON files.
+struct IngestionSummary {
+  std::uint64_t total{0};
+  NanoTime first_ts{0};
+  NanoTime last_ts{0};
+};
+
+// Runs the Standard-task pipeline over a single NDJSON file.
+// - Parses every line into a MarketDataEvent.
+// - Remembers the first `head_n` and last `tail_n` events.
+// - Writes a readable summary to `out` (total, first/last ts, head and tail
+//   samples, each rendered via processMarketDataEvent-equivalent output).
+//
+// Returns accumulated statistics.
+// Throws std::runtime_error on IO/parse failure.
+IngestionSummary runStandardTask(const std::filesystem::path &path,
+                                 std::size_t head_n, std::size_t tail_n,
+                                 std::ostream &out);
+
+} // namespace cmf

--- a/src/market_data/EventSource.hpp
+++ b/src/market_data/EventSource.hpp
@@ -1,0 +1,75 @@
+// EventSource — abstraction over one stream of chronologically-sorted events.
+//
+// Implementations:
+//   * SpscQueueSource — wraps a SpscRingQueue<MarketDataEvent> fed by a
+//     producer thread (real ingestion path).
+//   * VectorEventSource — drains a pre-populated std::vector (unit tests).
+//
+// The pop() method blocks until either an event is available (returns true)
+// or the underlying stream is permanently exhausted (returns false).
+
+#pragma once
+
+#include "market_data/MarketDataEvent.hpp"
+#include "market_data/SpscRingQueue.hpp"
+
+#include <thread>
+#include <utility>
+#include <vector>
+
+namespace cmf {
+
+class IEventSource {
+public:
+  IEventSource() = default;
+  virtual ~IEventSource() = default;
+
+  IEventSource(const IEventSource &) = delete;
+  IEventSource &operator=(const IEventSource &) = delete;
+
+  // Blocks until an event is produced, or until the upstream signals done.
+  // Returns true and sets `out` on success, false at end-of-stream.
+  virtual bool pop(MarketDataEvent &out) = 0;
+};
+
+// Wraps an SPSC ring queue: spins with yield until either an item becomes
+// available or the producer closes the queue and the queue drains.
+class SpscQueueSource final : public IEventSource {
+public:
+  explicit SpscQueueSource(SpscRingQueue<MarketDataEvent> &q) noexcept
+      : q_(&q) {}
+
+  bool pop(MarketDataEvent &out) override {
+    while (true) {
+      if (q_->pop(out))
+        return true;
+      if (q_->done())
+        return false;
+      std::this_thread::yield();
+    }
+  }
+
+private:
+  SpscRingQueue<MarketDataEvent> *q_;
+};
+
+// Drains a pre-populated vector in index order. Non-blocking.
+class VectorEventSource final : public IEventSource {
+public:
+  explicit VectorEventSource(std::vector<MarketDataEvent> items) noexcept
+      : items_(std::move(items)) {}
+
+  bool pop(MarketDataEvent &out) override {
+    if (idx_ >= items_.size())
+      return false;
+    out = std::move(items_[idx_]);
+    ++idx_;
+    return true;
+  }
+
+private:
+  std::vector<MarketDataEvent> items_;
+  std::size_t idx_{0};
+};
+
+} // namespace cmf

--- a/src/market_data/FileProducer.cpp
+++ b/src/market_data/FileProducer.cpp
@@ -1,0 +1,48 @@
+#include "market_data/FileProducer.hpp"
+
+#include "market_data/MmapMboSource.hpp"
+
+#include <utility>
+
+namespace cmf {
+
+FileProducer::FileProducer(std::filesystem::path path,
+                           std::size_t queue_capacity)
+    : path_(std::move(path)),
+      queue_(std::make_unique<SpscRingQueue<MarketDataEvent>>(
+          queue_capacity)) {}
+
+FileProducer::~FileProducer() {
+  try {
+    join();
+  } catch (...) {
+    // Swallow: dtor must be noexcept-equivalent.
+  }
+}
+
+void FileProducer::start() { thread_ = std::thread(&FileProducer::run, this); }
+
+void FileProducer::join() {
+  if (thread_.joinable())
+    thread_.join();
+}
+
+void FileProducer::run() {
+  try {
+    MmapMboSource source(path_);
+    MarketDataEvent event;
+    std::uint64_t n = 0;
+    while (source.next(event)) {
+      // Backpressure: spin-yield while the consumer drains.
+      while (!queue_->push(std::move(event)))
+        std::this_thread::yield();
+      ++n;
+    }
+    lines_.store(n, std::memory_order_release);
+  } catch (...) {
+    error_ = std::current_exception();
+  }
+  queue_->close();
+}
+
+} // namespace cmf

--- a/src/market_data/FileProducer.hpp
+++ b/src/market_data/FileProducer.hpp
@@ -1,0 +1,61 @@
+// FileProducer — one thread: file -> parser -> SpscRingQueue.
+
+#pragma once
+
+#include "market_data/MarketDataEvent.hpp"
+#include "market_data/SpscRingQueue.hpp"
+
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+#include <exception>
+#include <filesystem>
+#include <memory>
+#include <thread>
+
+namespace cmf {
+
+class FileProducer {
+public:
+  // Default queue capacity — 64Ki slots. Tune via ctor if producer/consumer
+  // throughput mismatch causes sustained backpressure or idle consumer.
+  static constexpr std::size_t kDefaultQueueCapacity = 64 * 1024;
+
+  explicit FileProducer(
+      std::filesystem::path path,
+      std::size_t queue_capacity = kDefaultQueueCapacity);
+
+  // The destructor joins the thread if still running. Throws nothing.
+  ~FileProducer();
+
+  FileProducer(const FileProducer &) = delete;
+  FileProducer &operator=(const FileProducer &) = delete;
+
+  // Launches the reader/parser thread. Call exactly once.
+  void start();
+
+  // Joins the thread (safe to call multiple times).
+  void join();
+
+  // Parsed-and-enqueued line counter (exact once join() returns).
+  std::uint64_t linesProduced() const noexcept {
+    return lines_.load(std::memory_order_acquire);
+  }
+
+  // Any exception thrown on the producer thread. Null if clean.
+  std::exception_ptr error() const noexcept { return error_; }
+
+  SpscRingQueue<MarketDataEvent> &queue() noexcept { return *queue_; }
+  const std::filesystem::path &path() const noexcept { return path_; }
+
+private:
+  void run();
+
+  std::filesystem::path path_;
+  std::unique_ptr<SpscRingQueue<MarketDataEvent>> queue_;
+  std::thread thread_;
+  std::atomic<std::uint64_t> lines_{0};
+  std::exception_ptr error_;
+};
+
+} // namespace cmf

--- a/src/market_data/HardTask.cpp
+++ b/src/market_data/HardTask.cpp
@@ -1,0 +1,207 @@
+#include "market_data/HardTask.hpp"
+
+#include "market_data/Consumer.hpp"
+#include "market_data/EventSource.hpp"
+#include "market_data/FileProducer.hpp"
+#include "market_data/Merger.hpp"
+
+#include <algorithm>
+#include <cstdint>
+#include <exception>
+#include <iomanip>
+#include <limits>
+#include <memory>
+#include <ostream>
+#include <sstream>
+#include <stdexcept>
+#include <thread>
+
+namespace cmf {
+
+std::string toString(MergerKind kind) {
+  switch (kind) {
+  case MergerKind::Flat:
+    return "Flat";
+  case MergerKind::Hierarchy:
+    return "Hierarchy";
+  }
+  return "Unknown";
+}
+
+std::vector<std::filesystem::path>
+listMboJsonFiles(const std::filesystem::path &dir) {
+  namespace fs = std::filesystem;
+  std::vector<fs::path> files;
+  for (const auto &entry : fs::directory_iterator(dir)) {
+    if (!entry.is_regular_file())
+      continue;
+    const auto name = entry.path().filename().string();
+    if (name.size() < 10)
+      continue;
+    // Match Databento naming: *.mbo.json
+    if (name.find(".mbo.json") != std::string::npos)
+      files.push_back(entry.path());
+  }
+  std::sort(files.begin(), files.end());
+  return files;
+}
+
+namespace {
+
+// FNV-1a 64-bit step. Used to order-sensitively fingerprint the dispatched
+// stream so we can cross-check Flat vs Hierarchy produced identical output.
+constexpr std::uint64_t kFnvOffset = 0xcbf29ce484222325ULL;
+constexpr std::uint64_t kFnvPrime = 0x100000001b3ULL;
+
+inline std::uint64_t fnv1aMix(std::uint64_t h, std::uint64_t x) noexcept {
+  // Mix 8 bytes little-endian.
+  for (int i = 0; i < 8; ++i) {
+    h ^= static_cast<std::uint8_t>(x & 0xFF);
+    h *= kFnvPrime;
+    x >>= 8;
+  }
+  return h;
+}
+
+std::unique_ptr<IMerger>
+makeMerger(MergerKind kind,
+           const std::vector<IEventSource *> &sources) {
+  switch (kind) {
+  case MergerKind::Flat:
+    return std::make_unique<FlatMerger>(sources);
+  case MergerKind::Hierarchy:
+    return std::make_unique<HierarchyMerger>(sources);
+  }
+  throw std::invalid_argument("HardTask: unknown MergerKind");
+}
+
+} // namespace
+
+BenchmarkResult runHardTask(const std::vector<std::filesystem::path> &files,
+                            MergerKind kind, bool verbose,
+                            std::size_t queue_capacity) {
+  BenchmarkResult result;
+  result.strategy = toString(kind);
+
+  if (files.empty())
+    return result;
+
+  // 1) Build producers (creates queues, no threads yet).
+  std::vector<std::unique_ptr<FileProducer>> producers;
+  producers.reserve(files.size());
+  for (const auto &f : files)
+    producers.push_back(std::make_unique<FileProducer>(f, queue_capacity));
+
+  // 2) Start producer threads BEFORE constructing the merger — the merger's
+  //    constructor blocks on each source's first event.
+  const auto t_start = std::chrono::steady_clock::now();
+  for (auto &p : producers)
+    p->start();
+
+  // 3) Wrap each queue as an IEventSource.
+  std::vector<std::unique_ptr<SpscQueueSource>> sources_owned;
+  sources_owned.reserve(producers.size());
+  std::vector<IEventSource *> sources;
+  sources.reserve(producers.size());
+  for (auto &p : producers) {
+    sources_owned.push_back(std::make_unique<SpscQueueSource>(p->queue()));
+    sources.push_back(sources_owned.back().get());
+  }
+
+  // 4) Build merger. This may block briefly while it seeds from each source.
+  auto merger = makeMerger(kind, sources);
+
+  // 5) Dispatcher thread — drains the merged stream in a dedicated OS thread
+  //    as required by the task spec ("Launches one dispatcher thread that
+  //    reads sequentially from the merged queue"). Results are captured into
+  //    outer-scope locals by reference.
+  std::uint64_t total = 0;
+  NanoTime first_ts = 0;
+  NanoTime last_ts = 0;
+  std::uint64_t fingerprint = kFnvOffset;
+  std::exception_ptr dispatcher_error;
+
+  std::thread dispatcher([&] {
+    try {
+      MarketDataEvent event;
+      NanoTime prev_ts = std::numeric_limits<NanoTime>::min();
+      while (merger->next(event)) {
+        if (event.ts_recv < prev_ts) {
+          throw std::runtime_error(
+              "HardTask: chronological order violated at event #" +
+              std::to_string(total));
+        }
+        prev_ts = event.ts_recv;
+        if (total == 0)
+          first_ts = event.ts_recv;
+        last_ts = event.ts_recv;
+
+        fingerprint =
+            fnv1aMix(fingerprint, static_cast<std::uint64_t>(event.ts_recv));
+        fingerprint = fnv1aMix(fingerprint, event.instrument_id);
+        fingerprint = fnv1aMix(fingerprint, event.order_id);
+        fingerprint =
+            fnv1aMix(fingerprint, static_cast<std::uint64_t>(event.sequence));
+
+        if (verbose)
+          processMarketDataEvent(event);
+
+        ++total;
+      }
+    } catch (...) {
+      dispatcher_error = std::current_exception();
+      // Drain remaining events to unblock producers (they would otherwise
+      // spin forever on queue->push backpressure with no consumer).
+      try {
+        MarketDataEvent discard;
+        while (merger->next(discard)) {
+        }
+      } catch (...) {
+        // Ignore secondary errors during error-path drain.
+      }
+    }
+  });
+
+  dispatcher.join();
+
+  // 6) Join producers; propagate any error (dispatcher's first).
+  for (auto &p : producers)
+    p->join();
+
+  const auto t_end = std::chrono::steady_clock::now();
+
+  if (dispatcher_error)
+    std::rethrow_exception(dispatcher_error);
+
+  for (auto &p : producers) {
+    if (auto eptr = p->error()) {
+      std::rethrow_exception(eptr);
+    }
+  }
+
+  result.total = total;
+  result.first_ts = first_ts;
+  result.last_ts = last_ts;
+  result.elapsed =
+      std::chrono::duration_cast<std::chrono::nanoseconds>(t_end - t_start);
+  result.fingerprint = fingerprint;
+  return result;
+}
+
+void printBenchmarkResult(std::ostream &os, const BenchmarkResult &r) {
+  const double secs =
+      static_cast<double>(r.elapsed.count()) / 1e9;
+  const double mps = r.throughputMps();
+
+  std::ostringstream line;
+  line << std::left << std::setw(10) << (r.strategy + ":")
+       << " total=" << std::setw(12) << r.total
+       << " elapsed=" << std::fixed << std::setprecision(3) << secs << " s"
+       << " throughput=" << std::fixed << std::setprecision(0) << mps
+       << " msg/s"
+       << " first_ts=" << r.first_ts << " last_ts=" << r.last_ts
+       << " fp=0x" << std::hex << r.fingerprint << std::dec;
+  os << line.str() << '\n';
+}
+
+} // namespace cmf

--- a/src/market_data/HardTask.hpp
+++ b/src/market_data/HardTask.hpp
@@ -1,0 +1,56 @@
+// HardTask — multi-file ingestion with two k-way merge strategies.
+
+#pragma once
+
+#include "common/BasicTypes.hpp"
+
+#include <chrono>
+#include <cstdint>
+#include <filesystem>
+#include <iosfwd>
+#include <string>
+#include <vector>
+
+namespace cmf {
+
+enum class MergerKind : std::uint8_t { Flat, Hierarchy };
+
+std::string toString(MergerKind kind);
+
+struct BenchmarkResult {
+  std::string strategy;
+  std::uint64_t total{0};
+  NanoTime first_ts{0};
+  NanoTime last_ts{0};
+  std::chrono::nanoseconds elapsed{0};
+  // Order-sensitive 64-bit fingerprint over the dispatched stream. Two
+  // mergers over the same input must produce identical fingerprints.
+  std::uint64_t fingerprint{0};
+
+  double throughputMps() const noexcept {
+    if (elapsed.count() <= 0)
+      return 0.0;
+    return static_cast<double>(total) * 1e9 /
+           static_cast<double>(elapsed.count());
+  }
+};
+
+// Lists *.mbo.json files in `dir` (non-recursive) sorted lexicographically.
+std::vector<std::filesystem::path>
+listMboJsonFiles(const std::filesystem::path &dir);
+
+// Runs the full Hard-task pipeline:
+//   * spawns one FileProducer per file,
+//   * builds the requested merger,
+//   * acts as the single dispatcher thread that drains the merger and calls
+//     processMarketDataEvent (if verbose) while verifying chronological order.
+//
+// Throws std::runtime_error on any producer error or chronology violation.
+BenchmarkResult runHardTask(const std::vector<std::filesystem::path> &files,
+                            MergerKind kind, bool verbose,
+                            std::size_t queue_capacity = 64 * 1024);
+
+// Pretty-prints a BenchmarkResult to `os`.
+void printBenchmarkResult(std::ostream &os, const BenchmarkResult &r);
+
+} // namespace cmf

--- a/src/market_data/MappedFile.cpp
+++ b/src/market_data/MappedFile.cpp
@@ -1,0 +1,92 @@
+#include "market_data/MappedFile.hpp"
+
+#include <cerrno>
+#include <cstring>
+#include <fcntl.h>
+#include <stdexcept>
+#include <string>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+namespace cmf {
+
+MappedFile::MappedFile(const std::filesystem::path &path) {
+  fd_ = ::open(path.c_str(), O_RDONLY);
+  if (fd_ < 0) {
+    throw std::runtime_error("MappedFile: open '" + path.string() +
+                             "': " + std::strerror(errno));
+  }
+
+  struct stat st {};
+  if (::fstat(fd_, &st) != 0) {
+    const int err = errno;
+    ::close(fd_);
+    fd_ = -1;
+    throw std::runtime_error(std::string{"MappedFile: fstat: "} +
+                             std::strerror(err));
+  }
+  size_ = static_cast<std::size_t>(st.st_size);
+
+  if (size_ == 0) {
+    // Empty file: nothing to map. data() stays null; consumer must handle
+    // the empty range.
+    return;
+  }
+
+  int flags = MAP_PRIVATE;
+#ifdef MAP_POPULATE
+  flags |= MAP_POPULATE; // Linux: pre-fault pages in the kernel.
+#endif
+  void *addr = ::mmap(nullptr, size_, PROT_READ, flags, fd_, 0);
+  if (addr == MAP_FAILED) {
+    const int err = errno;
+    ::close(fd_);
+    fd_ = -1;
+    size_ = 0;
+    throw std::runtime_error(std::string{"MappedFile: mmap: "} +
+                             std::strerror(err));
+  }
+  data_ = static_cast<const char *>(addr);
+
+  // Hint the kernel to aggressively prefetch for forward sequential scan.
+  // Ignore madvise errors — they're purely advisory.
+  ::madvise(const_cast<void *>(static_cast<const void *>(data_)), size_,
+            MADV_SEQUENTIAL);
+}
+
+MappedFile::MappedFile(MappedFile &&other) noexcept
+    : data_(other.data_), size_(other.size_), fd_(other.fd_) {
+  other.data_ = nullptr;
+  other.size_ = 0;
+  other.fd_ = -1;
+}
+
+MappedFile &MappedFile::operator=(MappedFile &&other) noexcept {
+  if (this != &other) {
+    release();
+    data_ = other.data_;
+    size_ = other.size_;
+    fd_ = other.fd_;
+    other.data_ = nullptr;
+    other.size_ = 0;
+    other.fd_ = -1;
+  }
+  return *this;
+}
+
+MappedFile::~MappedFile() { release(); }
+
+void MappedFile::release() noexcept {
+  if (data_ != nullptr && size_ != 0) {
+    ::munmap(const_cast<char *>(data_), size_);
+  }
+  if (fd_ >= 0) {
+    ::close(fd_);
+  }
+  data_ = nullptr;
+  size_ = 0;
+  fd_ = -1;
+}
+
+} // namespace cmf

--- a/src/market_data/MappedFile.hpp
+++ b/src/market_data/MappedFile.hpp
@@ -1,0 +1,41 @@
+// MappedFile — RAII wrapper around a read-only POSIX mmap.
+//
+// Linux and macOS only (POSIX mmap / madvise). On empty files the mapping is
+// skipped entirely: data() returns nullptr and size() returns 0.
+
+#pragma once
+
+#include <cstddef>
+#include <filesystem>
+#include <string_view>
+
+namespace cmf {
+
+class MappedFile {
+public:
+  // Opens the file read-only, mmaps the full length, and advises the kernel
+  // that access will be sequential (triggers read-ahead). Throws
+  // std::runtime_error with errno context on any failure.
+  explicit MappedFile(const std::filesystem::path &path);
+
+  ~MappedFile();
+
+  MappedFile(const MappedFile &) = delete;
+  MappedFile &operator=(const MappedFile &) = delete;
+
+  MappedFile(MappedFile &&other) noexcept;
+  MappedFile &operator=(MappedFile &&other) noexcept;
+
+  const char *data() const noexcept { return data_; }
+  std::size_t size() const noexcept { return size_; }
+  std::string_view view() const noexcept { return {data_, size_}; }
+
+private:
+  void release() noexcept;
+
+  const char *data_{nullptr};
+  std::size_t size_{0};
+  int fd_{-1};
+};
+
+} // namespace cmf

--- a/src/market_data/MarketDataEvent.cpp
+++ b/src/market_data/MarketDataEvent.cpp
@@ -1,0 +1,68 @@
+#include "market_data/MarketDataEvent.hpp"
+
+#include <ostream>
+#include <stdexcept>
+#include <string>
+
+namespace cmf {
+
+MdAction parseAction(char c) {
+  switch (c) {
+  case 'A':
+    return MdAction::Add;
+  case 'M':
+    return MdAction::Modify;
+  case 'C':
+    return MdAction::Cancel;
+  case 'R':
+    return MdAction::Clear;
+  case 'T':
+    return MdAction::Trade;
+  case 'F':
+    return MdAction::Fill;
+  case 'N':
+    return MdAction::None;
+  default:
+    throw std::invalid_argument(std::string{"invalid MD action: '"} + c + "'");
+  }
+}
+
+Side parseSide(char c) {
+  switch (c) {
+  case 'B':
+    return Side::Buy;
+  case 'A':
+    return Side::Sell;
+  case 'N':
+    return Side::None;
+  default:
+    throw std::invalid_argument(std::string{"invalid MD side: '"} + c + "'");
+  }
+}
+
+bool operator<(const MarketDataEvent &a, const MarketDataEvent &b) noexcept {
+  if (a.ts_recv != b.ts_recv)
+    return a.ts_recv < b.ts_recv;
+  if (a.sequence != b.sequence)
+    return a.sequence < b.sequence;
+  return a.instrument_id < b.instrument_id;
+}
+
+bool operator>(const MarketDataEvent &a, const MarketDataEvent &b) noexcept {
+  return b < a;
+}
+
+std::ostream &operator<<(std::ostream &os, const MarketDataEvent &e) {
+  os << "ts_recv=" << e.ts_recv << " ts_event=" << e.ts_event
+     << " order_id=" << e.order_id << " side=" << static_cast<int>(e.side)
+     << " price=";
+  if (e.priceDefined())
+    os << e.priceAsDouble();
+  else
+    os << "UNDEF";
+  os << " size=" << e.size << " action=" << static_cast<char>(e.action)
+     << " instrument_id=" << e.instrument_id << " symbol=" << e.symbol;
+  return os;
+}
+
+} // namespace cmf

--- a/src/market_data/MarketDataEvent.hpp
+++ b/src/market_data/MarketDataEvent.hpp
@@ -1,0 +1,77 @@
+// MarketDataEvent — single L3 (MBO) message consumed from the feed.
+
+#pragma once
+
+#include "common/BasicTypes.hpp"
+
+#include <cstdint>
+#include <iosfwd>
+#include <limits>
+#include <string>
+
+namespace cmf {
+
+// Action codes from Databento MBO schema.
+// See: agent-info/documentation.md §Action.
+enum class MdAction : char {
+  None = 'N',
+  Add = 'A',
+  Modify = 'M',
+  Cancel = 'C',
+  Clear = 'R',
+  Trade = 'T',
+  Fill = 'F',
+};
+
+// Parses a one-character action code. Throws std::invalid_argument on unknown.
+MdAction parseAction(char c);
+
+// Parses a one-character side code: 'B' -> Buy, 'A' -> Sell, 'N' -> None.
+// Throws std::invalid_argument on unknown.
+Side parseSide(char c);
+
+// Market data event — one L3 (MBO) message from the feed.
+// Sorted chronologically by (ts_recv, sequence, instrument_id) for k-way merge.
+struct MarketDataEvent {
+  // Fixed-point price: 1 unit == 1e-9. Matches DBN on-wire representation
+  // and avoids per-event std::stod / double parsing on the hot path.
+  static constexpr std::int64_t kPriceScale = 1'000'000'000LL;
+  static constexpr std::int64_t kUndefPrice =
+      (std::numeric_limits<std::int64_t>::max)();
+
+  NanoTime ts_recv{0};  // primary key for global chronological order
+  NanoTime ts_event{0}; // matching engine timestamp
+  std::int32_t ts_in_delta{0};
+  std::uint32_t sequence{0};
+  std::uint64_t instrument_id{0};
+  std::uint16_t publisher_id{0};
+  std::uint16_t flags{0};
+  std::uint8_t rtype{0};
+  std::uint8_t channel_id{0};
+  MdAction action{MdAction::None};
+  Side side{Side::None};
+  OrderId order_id{0};
+  std::int64_t price{kUndefPrice};
+  std::uint32_t size{0};
+  std::string symbol;
+
+  bool priceDefined() const noexcept { return price != kUndefPrice; }
+
+  // Converts the fixed-point price back to a double for display or use by
+  // float-centric downstream code. NaN when undefined.
+  double priceAsDouble() const noexcept {
+    return priceDefined()
+               ? static_cast<double>(price) /
+                     static_cast<double>(kPriceScale)
+               : std::numeric_limits<double>::quiet_NaN();
+  }
+};
+
+// Strict weak ordering by (ts_recv, sequence, instrument_id).
+bool operator<(const MarketDataEvent &a, const MarketDataEvent &b) noexcept;
+bool operator>(const MarketDataEvent &a, const MarketDataEvent &b) noexcept;
+
+// Human-readable one-line dump for verification output.
+std::ostream &operator<<(std::ostream &os, const MarketDataEvent &e);
+
+} // namespace cmf

--- a/src/market_data/Merger.cpp
+++ b/src/market_data/Merger.cpp
@@ -1,0 +1,148 @@
+#include "market_data/Merger.hpp"
+
+#include <algorithm>
+#include <utility>
+
+namespace cmf {
+
+// ---------------------------------------------------------------------------
+// FlatMerger
+// ---------------------------------------------------------------------------
+
+FlatMerger::FlatMerger(std::vector<IEventSource *> sources)
+    : sources_(std::move(sources)) {
+  heap_.reserve(sources_.size());
+  for (std::size_t i = 0; i < sources_.size(); ++i) {
+    MarketDataEvent e;
+    if (sources_[i]->pop(e)) {
+      heap_.push_back({std::move(e), i});
+      std::push_heap(heap_.begin(), heap_.end(), Greater{});
+    }
+  }
+}
+
+bool FlatMerger::next(MarketDataEvent &out) {
+  if (heap_.empty())
+    return false;
+
+  std::pop_heap(heap_.begin(), heap_.end(), Greater{});
+  HeapEntry &popped = heap_.back();
+  out = std::move(popped.event);
+  const std::size_t src_idx = popped.src_idx;
+  heap_.pop_back();
+
+  MarketDataEvent next_e;
+  if (sources_[src_idx]->pop(next_e)) {
+    heap_.push_back({std::move(next_e), src_idx});
+    std::push_heap(heap_.begin(), heap_.end(), Greater{});
+  }
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// HierarchyMerger::Node — abstract internal node, defined here so the
+// destructor of the forward-declared Node can be instantiated.
+// ---------------------------------------------------------------------------
+class HierarchyMerger::Node {
+public:
+  Node() = default;
+  virtual ~Node() = default;
+  Node(const Node &) = delete;
+  Node &operator=(const Node &) = delete;
+  virtual bool pullNext(MarketDataEvent &out) = 0;
+};
+
+namespace {
+
+class LeafNode final : public HierarchyMerger::Node {
+public:
+  explicit LeafNode(IEventSource *src) noexcept : src_(src) {}
+
+  bool pullNext(MarketDataEvent &out) override { return src_->pop(out); }
+
+private:
+  IEventSource *src_;
+};
+
+class PairNode final : public HierarchyMerger::Node {
+public:
+  PairNode(std::unique_ptr<HierarchyMerger::Node> l,
+           std::unique_ptr<HierarchyMerger::Node> r)
+      : left_(std::move(l)), right_(std::move(r)) {
+    left_valid_ = left_->pullNext(left_head_);
+    right_valid_ = right_->pullNext(right_head_);
+  }
+
+  bool pullNext(MarketDataEvent &out) override {
+    if (!left_valid_ && !right_valid_)
+      return false;
+
+    if (!right_valid_) {
+      out = std::move(left_head_);
+      left_valid_ = left_->pullNext(left_head_);
+      return true;
+    }
+    if (!left_valid_) {
+      out = std::move(right_head_);
+      right_valid_ = right_->pullNext(right_head_);
+      return true;
+    }
+    if (left_head_ < right_head_) {
+      out = std::move(left_head_);
+      left_valid_ = left_->pullNext(left_head_);
+    } else {
+      out = std::move(right_head_);
+      right_valid_ = right_->pullNext(right_head_);
+    }
+    return true;
+  }
+
+private:
+  std::unique_ptr<HierarchyMerger::Node> left_;
+  std::unique_ptr<HierarchyMerger::Node> right_;
+  MarketDataEvent left_head_;
+  MarketDataEvent right_head_;
+  bool left_valid_{false};
+  bool right_valid_{false};
+};
+
+} // namespace
+
+// ---------------------------------------------------------------------------
+// HierarchyMerger
+// ---------------------------------------------------------------------------
+
+HierarchyMerger::HierarchyMerger(const std::vector<IEventSource *> &sources) {
+  if (sources.empty())
+    return;
+
+  std::vector<std::unique_ptr<Node>> level;
+  level.reserve(sources.size());
+  for (IEventSource *s : sources)
+    level.push_back(std::make_unique<LeafNode>(s));
+
+  // Build bottom-up: pair adjacent nodes; odd node carries over.
+  while (level.size() > 1) {
+    std::vector<std::unique_ptr<Node>> next_level;
+    next_level.reserve((level.size() + 1) / 2);
+    for (std::size_t i = 0; i + 1 < level.size(); i += 2) {
+      next_level.push_back(std::make_unique<PairNode>(std::move(level[i]),
+                                                      std::move(level[i + 1])));
+    }
+    if (level.size() % 2 == 1)
+      next_level.push_back(std::move(level.back()));
+    level = std::move(next_level);
+  }
+  root_ = std::move(level[0]);
+}
+
+bool HierarchyMerger::next(MarketDataEvent &out) {
+  if (!root_)
+    return false;
+  return root_->pullNext(out);
+}
+
+// Out-of-line dtor so the forward-declared Node type can be destroyed.
+HierarchyMerger::~HierarchyMerger() = default;
+
+} // namespace cmf

--- a/src/market_data/Merger.hpp
+++ b/src/market_data/Merger.hpp
@@ -1,0 +1,77 @@
+// Merger — merges N chronologically-sorted IEventSource streams into one.
+//
+// Two strategies are provided (task_1.md §Hard Task):
+//   * FlatMerger      — single k-way min-heap across all source heads.
+//   * HierarchyMerger — binary tree of PairMergers.
+//
+// Both preserve strict chronological order by (ts_recv, sequence,
+// instrument_id) (see MarketDataEvent::operator<).
+
+#pragma once
+
+#include "market_data/EventSource.hpp"
+#include "market_data/MarketDataEvent.hpp"
+
+#include <cstddef>
+#include <memory>
+#include <vector>
+
+namespace cmf {
+
+class IMerger {
+public:
+  IMerger() = default;
+  virtual ~IMerger() = default;
+
+  IMerger(const IMerger &) = delete;
+  IMerger &operator=(const IMerger &) = delete;
+
+  // Returns the globally-next event across all sources, or false when all
+  // sources are exhausted.
+  virtual bool next(MarketDataEvent &out) = 0;
+};
+
+// ---------------------------------------------------------------------------
+// FlatMerger: one heap holding at most one pending event per source.
+// ---------------------------------------------------------------------------
+class FlatMerger final : public IMerger {
+public:
+  explicit FlatMerger(std::vector<IEventSource *> sources);
+
+  bool next(MarketDataEvent &out) override;
+
+private:
+  struct HeapEntry {
+    MarketDataEvent event;
+    std::size_t src_idx;
+  };
+  struct Greater {
+    bool operator()(const HeapEntry &a, const HeapEntry &b) const noexcept {
+      return a.event > b.event;
+    }
+  };
+
+  std::vector<IEventSource *> sources_;
+  std::vector<HeapEntry> heap_; // min-heap via std::greater over events
+};
+
+// ---------------------------------------------------------------------------
+// HierarchyMerger: binary tree of pairwise mergers.
+// ---------------------------------------------------------------------------
+class HierarchyMerger final : public IMerger {
+public:
+  // Opaque internal tree node type; defined in Merger.cpp. Declared public
+  // only so LeafNode/PairNode subclasses (in Merger.cpp's anonymous
+  // namespace) can derive from it. Not part of the stable API.
+  class Node;
+
+  explicit HierarchyMerger(const std::vector<IEventSource *> &sources);
+  ~HierarchyMerger() override;
+
+  bool next(MarketDataEvent &out) override;
+
+private:
+  std::unique_ptr<Node> root_;
+};
+
+} // namespace cmf

--- a/src/market_data/MmapMboSource.cpp
+++ b/src/market_data/MmapMboSource.cpp
@@ -1,0 +1,37 @@
+#include "market_data/MmapMboSource.hpp"
+
+#include <cstring>
+#include <stdexcept>
+#include <string_view>
+
+namespace cmf {
+
+namespace {
+
+// Every Databento MBO record from XEUR/EOBI starts with this prefix. Checking
+// it once per file converts silent parser UB (on format changes) into a loud
+// runtime error.
+constexpr std::string_view kExpectedPrefix = R"({"ts_recv":")";
+
+} // namespace
+
+MmapMboSource::MmapMboSource(const std::filesystem::path &path)
+    : path_(path), file_(path) {
+  if (file_.size() == 0) {
+    // Empty file — legal (no events). Parser over null range returns false.
+    parser_.reset(nullptr, nullptr);
+    return;
+  }
+
+  if (file_.size() < kExpectedPrefix.size() ||
+      std::memcmp(file_.data(), kExpectedPrefix.data(),
+                  kExpectedPrefix.size()) != 0) {
+    throw std::runtime_error(
+        "MmapMboSource: unexpected file prefix (not Databento MBO?) for '" +
+        path.string() + "'");
+  }
+
+  parser_.reset(file_.data(), file_.data() + file_.size());
+}
+
+} // namespace cmf

--- a/src/market_data/MmapMboSource.hpp
+++ b/src/market_data/MmapMboSource.hpp
@@ -1,0 +1,38 @@
+// MmapMboSource — opens one Databento MBO NDJSON file via mmap and yields
+// events one at a time. Composition of MappedFile + PositionalMboParser.
+
+#pragma once
+
+#include "market_data/MappedFile.hpp"
+#include "market_data/MarketDataEvent.hpp"
+#include "market_data/PositionalMboParser.hpp"
+
+#include <filesystem>
+
+namespace cmf {
+
+class MmapMboSource {
+public:
+  // Opens and mmaps the file. Validates that the content starts with the
+  // expected Databento prefix `{"ts_recv":"` so the positional parser
+  // doesn't silently produce nonsense when the feed format changes.
+  // Empty files are allowed (zero events). Throws std::runtime_error on
+  // I/O failure or unexpected prefix.
+  explicit MmapMboSource(const std::filesystem::path &path);
+
+  MmapMboSource(const MmapMboSource &) = delete;
+  MmapMboSource &operator=(const MmapMboSource &) = delete;
+
+  // Parses and returns the next event. Returns false at EOF.
+  bool next(MarketDataEvent &out) { return parser_.next(out); }
+
+  const std::filesystem::path &path() const noexcept { return path_; }
+  std::size_t size() const noexcept { return file_.size(); }
+
+private:
+  std::filesystem::path path_;
+  MappedFile file_;
+  PositionalMboParser parser_;
+};
+
+} // namespace cmf

--- a/src/market_data/PositionalMboParser.cpp
+++ b/src/market_data/PositionalMboParser.cpp
@@ -1,0 +1,202 @@
+#include "market_data/PositionalMboParser.hpp"
+
+#include <cstdint>
+
+namespace cmf {
+
+namespace {
+
+// --- primitive scanners (hot path, no bounds checks) ---------------------
+
+// "YYYY-MM-DDTHH:MM:SS.nnnnnnnnnZ" (30 chars) -> ns since epoch.
+// Unvalidating variant; caller guarantees format and width.
+inline NanoTime parseIsoTsFast(const char *p) noexcept {
+  auto d2 = [](const char *q) noexcept {
+    return static_cast<unsigned>(q[0] - '0') * 10u +
+           static_cast<unsigned>(q[1] - '0');
+  };
+  const int year = static_cast<int>(
+      static_cast<unsigned>(p[0] - '0') * 1000u +
+      static_cast<unsigned>(p[1] - '0') * 100u +
+      static_cast<unsigned>(p[2] - '0') * 10u +
+      static_cast<unsigned>(p[3] - '0'));
+  const unsigned month = d2(p + 5);
+  const unsigned day = d2(p + 8);
+  const unsigned hour = d2(p + 11);
+  const unsigned minute = d2(p + 14);
+  const unsigned second = d2(p + 17);
+  std::uint32_t nanos = 0;
+  for (int i = 0; i < 9; ++i)
+    nanos = nanos * 10u + static_cast<unsigned>(p[20 + i] - '0');
+
+  // Howard Hinnant's days_from_civil.
+  int y = year - static_cast<int>(month <= 2);
+  const int era = (y >= 0 ? y : y - 399) / 400;
+  const unsigned yoe = static_cast<unsigned>(y - era * 400);
+  const unsigned doy =
+      (153u * (month > 2 ? month - 3 : month + 9) + 2u) / 5u + day - 1u;
+  const unsigned doe = yoe * 365u + yoe / 4u - yoe / 100u + doy;
+  const std::int64_t days = static_cast<std::int64_t>(era) * 146097LL +
+                            static_cast<std::int64_t>(doe) - 719468LL;
+
+  const std::int64_t secs = days * 86400LL +
+                            static_cast<std::int64_t>(hour) * 3600LL +
+                            static_cast<std::int64_t>(minute) * 60LL +
+                            static_cast<std::int64_t>(second);
+  return secs * 1'000'000'000LL + static_cast<std::int64_t>(nanos);
+}
+
+// Reads an unquoted unsigned decimal. Returns pointer past the last digit.
+template <class T>
+inline const char *parseUInt(const char *p, T &out) noexcept {
+  std::uint64_t v = 0;
+  while (static_cast<unsigned>(*p - '0') < 10u) {
+    v = v * 10u + static_cast<std::uint64_t>(*p - '0');
+    ++p;
+  }
+  out = static_cast<T>(v);
+  return p;
+}
+
+// Reads an unquoted signed decimal (ts_in_delta may be negative).
+inline const char *parseInt32(const char *p, std::int32_t &out) noexcept {
+  const bool neg = (*p == '-');
+  if (neg)
+    ++p;
+  std::uint32_t v = 0;
+  while (static_cast<unsigned>(*p - '0') < 10u) {
+    v = v * 10u + static_cast<std::uint32_t>(*p - '0');
+    ++p;
+  }
+  out = neg ? -static_cast<std::int32_t>(v) : static_cast<std::int32_t>(v);
+  return p;
+}
+
+// Parses a pretty_px decimal price like "1.156100000" (quoted, 9 frac
+// digits, optional leading '-'). `p` must point AT the opening '"'.
+// Returns cursor past the closing '"'.
+inline const char *parsePrice(const char *p, std::int64_t &out) noexcept {
+  ++p; // opening quote
+  const bool neg = (*p == '-');
+  if (neg)
+    ++p;
+  std::int64_t ipart = 0;
+  while (*p != '.') {
+    ipart = ipart * 10 + static_cast<std::int64_t>(*p - '0');
+    ++p;
+  }
+  ++p; // '.'
+  std::uint32_t frac = 0;
+  for (int i = 0; i < 9; ++i)
+    frac = frac * 10u + static_cast<unsigned>(p[i] - '0');
+  p += 9;
+  const std::int64_t px =
+      ipart * MarketDataEvent::kPriceScale + static_cast<std::int64_t>(frac);
+  out = neg ? -px : px;
+  return p + 1; // past closing quote
+}
+
+} // namespace
+
+// -------------------------------------------------------------------------
+
+PositionalMboParser::PositionalMboParser(const char *begin,
+                                         const char *end) noexcept
+    : begin_(begin), cur_(begin), end_(end) {}
+
+void PositionalMboParser::reset(const char *begin, const char *end) noexcept {
+  begin_ = begin;
+  cur_ = begin;
+  end_ = end;
+}
+
+bool PositionalMboParser::next(MarketDataEvent &out) {
+  if (cur_ >= end_)
+    return false;
+  const char *p = cur_;
+
+  // {"ts_recv":"
+  p += 12;
+  out.ts_recv = parseIsoTsFast(p);
+  p += 30;
+
+  // ","hd":{"ts_event":"
+  p += 20;
+  out.ts_event = parseIsoTsFast(p);
+  p += 30;
+
+  // ","rtype":
+  p += 10;
+  p = parseUInt(p, out.rtype);
+
+  // ,"publisher_id":
+  p += 16;
+  p = parseUInt(p, out.publisher_id);
+
+  // ,"instrument_id":
+  p += 17;
+  p = parseUInt(p, out.instrument_id);
+
+  // },"action":"
+  p += 12;
+  out.action = static_cast<MdAction>(*p);
+  ++p;
+
+  // ","side":"
+  p += 10;
+  const char side_c = *p;
+  out.side = (side_c == 'B') ? Side::Buy
+                             : (side_c == 'A' ? Side::Sell : Side::None);
+  ++p;
+
+  // ","price":
+  p += 10;
+  if (*p == 'n') { // null
+    out.price = MarketDataEvent::kUndefPrice;
+    p += 4;
+  } else {
+    p = parsePrice(p, out.price);
+  }
+
+  // ,"size":
+  p += 8;
+  p = parseUInt(p, out.size);
+
+  // ,"channel_id":
+  p += 14;
+  p = parseUInt(p, out.channel_id);
+
+  // ,"order_id":"
+  p += 13;
+  p = parseUInt(p, out.order_id);
+  // p now points AT the closing '"' of order_id.
+
+  // ","flags":
+  p += 10;
+  p = parseUInt(p, out.flags);
+
+  // ,"ts_in_delta":
+  p += 15;
+  p = parseInt32(p, out.ts_in_delta);
+
+  // ,"sequence":
+  p += 12;
+  p = parseUInt(p, out.sequence);
+
+  // ,"symbol":"
+  p += 11;
+  const char *sym_begin = p;
+  while (*p != '"')
+    ++p; // symbols contain spaces/dots but never quotes
+  out.symbol.assign(sym_begin, static_cast<std::size_t>(p - sym_begin));
+
+  // closing '"' + '}' + optional '\n'
+  p += 2;
+  if (p < end_ && *p == '\n')
+    ++p;
+
+  cur_ = p;
+  return true;
+}
+
+} // namespace cmf

--- a/src/market_data/PositionalMboParser.hpp
+++ b/src/market_data/PositionalMboParser.hpp
@@ -1,0 +1,50 @@
+// PositionalMboParser — zero-allocation byte-level parser for Databento MBO
+// NDJSON records.
+//
+// Assumes the fixed key order and layout produced by XEUR/EOBI batch
+// downloads with `pretty_px=true`, `pretty_ts=true`:
+//   {"ts_recv":"...","hd":{"ts_event":"...","rtype":N,"publisher_id":N,
+//    "instrument_id":N},"action":"X","side":"X","price":"D.DDDDDDDDD"|null,
+//    "size":N,"channel_id":N,"order_id":"N","flags":N,"ts_in_delta":N,
+//    "sequence":N,"symbol":"TEXT"}\n
+//
+// Behaviour on malformed input is undefined — bounded by the end pointer
+// only at record boundaries, not mid-record. For trusted vendor data.
+
+#pragma once
+
+#include "market_data/MarketDataEvent.hpp"
+
+#include <cstddef>
+
+namespace cmf {
+
+class PositionalMboParser {
+public:
+  PositionalMboParser() noexcept = default;
+
+  // Constructs the parser over the half-open byte range [begin, end).
+  PositionalMboParser(const char *begin, const char *end) noexcept;
+
+  // (Re-)binds the parser to a new byte range.
+  void reset(const char *begin, const char *end) noexcept;
+
+  // Parses the next record into `out`. Returns false at end-of-buffer.
+  bool next(MarketDataEvent &out);
+
+  // Number of bytes consumed since the last reset().
+  std::size_t bytesConsumed() const noexcept {
+    return static_cast<std::size_t>(cur_ - begin_);
+  }
+
+  std::size_t totalBytes() const noexcept {
+    return static_cast<std::size_t>(end_ - begin_);
+  }
+
+private:
+  const char *begin_{nullptr};
+  const char *cur_{nullptr};
+  const char *end_{nullptr};
+};
+
+} // namespace cmf

--- a/src/market_data/SpscRingQueue.hpp
+++ b/src/market_data/SpscRingQueue.hpp
@@ -1,0 +1,117 @@
+// SpscRingQueue — bounded, single-producer / single-consumer lock-free queue.
+//
+// Contract:
+//   * Exactly one producer thread may call push() / close().
+//   * Exactly one consumer thread may call pop() / done().
+//   * Observers may call empty() / size() / capacity() / isClosed() at any
+//     time; results are eventually-consistent snapshots.
+//
+// Capacity is rounded up to the next power of two (>= 2) so the ring index
+// can be computed with a bitwise AND instead of a modulo.
+
+#pragma once
+
+#include <atomic>
+#include <cstddef>
+#include <stdexcept>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+namespace cmf {
+
+namespace detail {
+
+constexpr std::size_t nextPow2(std::size_t n) noexcept {
+  if (n < 2)
+    return 2;
+  --n;
+  for (std::size_t s = 1; s < sizeof(std::size_t) * 8; s <<= 1)
+    n |= n >> s;
+  return n + 1;
+}
+
+// Typical cache-line size on x86_64 and arm64.
+inline constexpr std::size_t kCacheLine = 64;
+
+} // namespace detail
+
+template <typename T> class SpscRingQueue {
+  static_assert(std::is_default_constructible_v<T>,
+                "SpscRingQueue requires a default-constructible T");
+  static_assert(std::is_nothrow_move_assignable_v<T> ||
+                    std::is_nothrow_copy_assignable_v<T>,
+                "SpscRingQueue requires a nothrow-assignable T for safety");
+
+public:
+  explicit SpscRingQueue(std::size_t requested_capacity)
+      : cap_(detail::nextPow2(requested_capacity)), mask_(cap_ - 1),
+        slots_(cap_) {
+    if (requested_capacity == 0)
+      throw std::invalid_argument("SpscRingQueue: capacity must be >= 1");
+  }
+
+  SpscRingQueue(const SpscRingQueue &) = delete;
+  SpscRingQueue &operator=(const SpscRingQueue &) = delete;
+  SpscRingQueue(SpscRingQueue &&) = delete;
+  SpscRingQueue &operator=(SpscRingQueue &&) = delete;
+
+  // Producer-side. Returns false when full.
+  bool push(T value) {
+    const std::size_t tail = tail_.load(std::memory_order_relaxed);
+    const std::size_t head = head_.load(std::memory_order_acquire);
+    if (tail - head == cap_)
+      return false;
+    slots_[tail & mask_] = std::move(value);
+    tail_.store(tail + 1, std::memory_order_release);
+    return true;
+  }
+
+  // Consumer-side. Returns false when empty.
+  bool pop(T &out) {
+    const std::size_t head = head_.load(std::memory_order_relaxed);
+    const std::size_t tail = tail_.load(std::memory_order_acquire);
+    if (head == tail)
+      return false;
+    out = std::move(slots_[head & mask_]);
+    head_.store(head + 1, std::memory_order_release);
+    return true;
+  }
+
+  // Producer-side. Called when the producer has no more items.
+  void close() noexcept { closed_.store(true, std::memory_order_release); }
+
+  bool isClosed() const noexcept {
+    return closed_.load(std::memory_order_acquire);
+  }
+
+  // True iff the producer has closed AND the consumer has drained it.
+  bool done() const noexcept { return isClosed() && empty(); }
+
+  bool empty() const noexcept {
+    return head_.load(std::memory_order_acquire) ==
+           tail_.load(std::memory_order_acquire);
+  }
+
+  // Snapshot size. May lag real value by a few items in the contended case.
+  std::size_t size() const noexcept {
+    const std::size_t t = tail_.load(std::memory_order_acquire);
+    const std::size_t h = head_.load(std::memory_order_acquire);
+    return t - h;
+  }
+
+  std::size_t capacity() const noexcept { return cap_; }
+
+private:
+  const std::size_t cap_;
+  const std::size_t mask_;
+  std::vector<T> slots_;
+
+  // Separate hot atomics on distinct cache lines to avoid false sharing
+  // between producer (tail_) and consumer (head_).
+  alignas(detail::kCacheLine) std::atomic<std::size_t> head_{0};
+  alignas(detail::kCacheLine) std::atomic<std::size_t> tail_{0};
+  alignas(detail::kCacheLine) std::atomic<bool> closed_{false};
+};
+
+} // namespace cmf

--- a/src/market_data/TimestampParser.cpp
+++ b/src/market_data/TimestampParser.cpp
@@ -1,0 +1,74 @@
+#include "market_data/TimestampParser.hpp"
+
+#include <cstdint>
+#include <stdexcept>
+#include <string>
+
+namespace cmf {
+
+namespace {
+
+// Howard Hinnant's days_from_civil: proleptic Gregorian date -> days since
+// 1970-01-01. Correct for any year, including pre-epoch.
+constexpr std::int64_t daysFromCivil(int y, unsigned m, unsigned d) noexcept {
+  y -= static_cast<int>(m <= 2);
+  const int era = (y >= 0 ? y : y - 399) / 400;
+  const unsigned yoe = static_cast<unsigned>(y - era * 400);
+  const unsigned doy = (153u * (m > 2 ? m - 3 : m + 9) + 2) / 5 + d - 1;
+  const unsigned doe = yoe * 365 + yoe / 4 - yoe / 100 + doy;
+  return static_cast<std::int64_t>(era) * 146097 +
+         static_cast<std::int64_t>(doe) - 719468;
+}
+
+template <std::size_t N>
+bool readDigits(std::string_view s, std::size_t o, unsigned &out) noexcept {
+  unsigned v = 0;
+  for (std::size_t i = 0; i < N; ++i) {
+    const char c = s[o + i];
+    if (c < '0' || c > '9')
+      return false;
+    v = v * 10u + static_cast<unsigned>(c - '0');
+  }
+  out = v;
+  return true;
+}
+
+[[noreturn]] void throwMalformed(std::string_view s, const char *reason) {
+  throw std::invalid_argument(std::string{"timestamp: "} + reason + ": '" +
+                              std::string{s} + "'");
+}
+
+} // namespace
+
+NanoTime parseDatabentoTimestamp(std::string_view s) {
+  // Expected: YYYY-MM-DDTHH:MM:SS.fffffffffZ
+  // Index:    0123456789012345678901234567890
+  //                     1111111111222222222
+  constexpr std::size_t kLen = 30;
+  if (s.size() != kLen)
+    throwMalformed(s, "wrong length");
+  if (s[4] != '-' || s[7] != '-' || s[10] != 'T' || s[13] != ':' ||
+      s[16] != ':' || s[19] != '.' || s[29] != 'Z')
+    throwMalformed(s, "wrong separators");
+
+  unsigned y = 0, mo = 0, d = 0, h = 0, mi = 0, se = 0, ns = 0;
+  const bool ok =
+      readDigits<4>(s, 0, y) && readDigits<2>(s, 5, mo) &&
+      readDigits<2>(s, 8, d) && readDigits<2>(s, 11, h) &&
+      readDigits<2>(s, 14, mi) && readDigits<2>(s, 17, se) &&
+      readDigits<9>(s, 20, ns);
+  if (!ok)
+    throwMalformed(s, "non-digit in field");
+
+  if (mo < 1 || mo > 12 || d < 1 || d > 31 || h > 23 || mi > 59 || se > 60)
+    throwMalformed(s, "field out of range");
+
+  const std::int64_t days = daysFromCivil(static_cast<int>(y), mo, d);
+  const std::int64_t secs = days * 86400LL +
+                            static_cast<std::int64_t>(h) * 3600LL +
+                            static_cast<std::int64_t>(mi) * 60LL +
+                            static_cast<std::int64_t>(se);
+  return secs * 1'000'000'000LL + static_cast<std::int64_t>(ns);
+}
+
+} // namespace cmf

--- a/src/market_data/TimestampParser.hpp
+++ b/src/market_data/TimestampParser.hpp
@@ -1,0 +1,17 @@
+// TimestampParser — ISO 8601 with 9-digit fractional seconds, UTC only.
+
+#pragma once
+
+#include "common/BasicTypes.hpp"
+
+#include <string_view>
+
+namespace cmf {
+
+// Parses a timestamp of the exact Databento pretty_ts format:
+//   "YYYY-MM-DDTHH:MM:SS.fffffffffZ"  (30 characters, UTC, 9-digit ns)
+// into nanoseconds since the UNIX epoch.
+// Throws std::invalid_argument on malformed input.
+NanoTime parseDatabentoTimestamp(std::string_view s);
+
+} // namespace cmf

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -20,6 +20,7 @@ add_executable(${TARGET} ${TEST_SRC})
 target_link_libraries(${TARGET} PRIVATE
     Catch2-static-lib
     back-tester-common
+    back-tester-market-data
 )
 
 # Register the tests with CTest

--- a/test/ConsumerTest.cpp
+++ b/test/ConsumerTest.cpp
@@ -1,0 +1,59 @@
+// Integration test for Consumer::runStandardTask on a small NDJSON file.
+
+#include "market_data/Consumer.hpp"
+
+#include "TempFile.hpp"
+#include "catch2/catch_all.hpp"
+
+#include <fstream>
+#include <sstream>
+#include <string>
+
+using namespace cmf;
+
+TEST_CASE("runStandardTask - processes 3-line NDJSON and returns summary",
+          "[Consumer]") {
+  TempFile tf("consumer_smoke.ndjson");
+  {
+    std::ofstream out(tf.getPath(), std::ios::binary);
+    REQUIRE(out.is_open());
+    // Three real lines drawn from XEUR-20260409-HTT6HHLT6R (Clear, Add,
+    // Cancel). Kept terse and escaped here to avoid the raw-string pitfall
+    // of embedding a "})" sequence.
+    out << R"({"ts_recv":"2026-04-06T18:53:08.486368500Z","hd":{"ts_event":"2026-04-06T18:53:08.486361336Z","rtype":160,"publisher_id":101,"instrument_id":453},"action":"R","side":"N","price":null,"size":0,"channel_id":23,"order_id":"0","flags":128,"ts_in_delta":7164,"sequence":0,"symbol":"FCEU SI 20281218 PS"})"
+        << "\n"
+        << R"({"ts_recv":"2026-04-07T00:00:00.246103535Z","hd":{"ts_event":"2026-04-07T00:00:00.246086711Z","rtype":160,"publisher_id":101,"instrument_id":436},"action":"A","side":"B","price":"1.157500000","size":20,"channel_id":23,"order_id":"10998892037100869125","flags":128,"ts_in_delta":985,"sequence":81255,"symbol":"FCEU SI 20260615 PS"})"
+        << "\n"
+        << R"({"ts_recv":"2026-04-07T00:00:02.399364973Z","hd":{"ts_event":"2026-04-07T00:00:02.399352523Z","rtype":160,"publisher_id":101,"instrument_id":436},"action":"C","side":"B","price":"1.157500000","size":20,"channel_id":23,"order_id":"10998892037100869125","flags":128,"ts_in_delta":882,"sequence":81351,"symbol":"FCEU SI 20260615 PS"})"
+        << "\n";
+  }
+
+  std::ostringstream buf;
+  const auto s =
+      runStandardTask(tf.getPath(), /*head_n=*/10, /*tail_n=*/10, buf);
+
+  REQUIRE(s.total == 3);
+  REQUIRE(s.first_ts == 1775501588486368500LL);
+  REQUIRE(s.last_ts == 1775520002399364973LL);
+
+  const std::string out = buf.str();
+  REQUIRE(out.find("Total messages: 3") != std::string::npos);
+  REQUIRE(out.find("=== First 3 events ===") != std::string::npos);
+  REQUIRE(out.find("=== Last 3 events ===") != std::string::npos);
+  REQUIRE(out.find("action=R") != std::string::npos);
+  REQUIRE(out.find("action=A") != std::string::npos);
+  REQUIRE(out.find("action=C") != std::string::npos);
+}
+
+TEST_CASE("runStandardTask - empty file yields zero total", "[Consumer]") {
+  TempFile tf("consumer_empty.ndjson");
+  {
+    std::ofstream out(tf.getPath(), std::ios::binary);
+  }
+
+  std::ostringstream buf;
+  const auto s = runStandardTask(tf.getPath(), 10, 10, buf);
+  REQUIRE(s.total == 0);
+  REQUIRE(s.first_ts == 0);
+  REQUIRE(s.last_ts == 0);
+}

--- a/test/HardTaskTest.cpp
+++ b/test/HardTaskTest.cpp
@@ -1,0 +1,127 @@
+// Integration tests for the Hard-task pipeline (FileProducer + merger +
+// dispatcher). Uses three small synthetic NDJSON files.
+
+#include "market_data/HardTask.hpp"
+
+#include "TempFile.hpp"
+#include "catch2/catch_all.hpp"
+
+#include <filesystem>
+#include <fstream>
+#include <sstream>
+#include <string>
+#include <vector>
+
+using namespace cmf;
+namespace fs = std::filesystem;
+
+namespace {
+
+// Render a JSON line with a given ts_recv second (as 2026-04-07T00:00:ss).
+std::string makeLine(int sec_offset, int sequence, int instrument_id,
+                     const char *action = "A", const char *side = "B") {
+  std::ostringstream os;
+  os << R"({"ts_recv":"2026-04-07T00:00:)" << (sec_offset < 10 ? "0" : "")
+     << sec_offset << R"(.000000000Z","hd":{"ts_event":"2026-04-07T00:00:)"
+     << (sec_offset < 10 ? "0" : "") << sec_offset
+     << R"(.000000000Z","rtype":160,"publisher_id":101,"instrument_id":)"
+     << instrument_id << R"(},"action":")" << action << R"(","side":")" << side
+     << R"(","price":"1.000000000","size":1,"channel_id":1,"order_id":"1","flags":0,"ts_in_delta":0,"sequence":)"
+     << sequence << R"(,"symbol":"TEST"})";
+  return os.str();
+}
+
+fs::path writeFile(const fs::path &dir, const std::string &name,
+                   const std::vector<std::string> &lines) {
+  const fs::path p = dir / name;
+  std::ofstream out(p, std::ios::binary);
+  REQUIRE(out.is_open());
+  for (const auto &l : lines)
+    out << l << "\n";
+  return p;
+}
+
+} // namespace
+
+TEST_CASE("runHardTask - merges 3 files in chronological order", "[HardTask]") {
+  const fs::path dir = fs::temp_directory_path() / "cmf_hardtask_test";
+  fs::remove_all(dir);
+  fs::create_directories(dir);
+
+  // Three files, each internally sorted, with interleaved timestamps.
+  std::vector<fs::path> files = {
+      writeFile(dir, "a.mbo.json",
+                {makeLine(0, 0, 10), makeLine(3, 1, 10), makeLine(6, 2, 10)}),
+      writeFile(dir, "b.mbo.json",
+                {makeLine(1, 0, 20), makeLine(4, 1, 20), makeLine(7, 2, 20)}),
+      writeFile(dir, "c.mbo.json",
+                {makeLine(2, 0, 30), makeLine(5, 1, 30), makeLine(8, 2, 30)}),
+  };
+
+  SECTION("FlatMerger") {
+    const auto r = runHardTask(files, MergerKind::Flat, /*verbose=*/false);
+    REQUIRE(r.total == 9);
+    REQUIRE(r.first_ts < r.last_ts);
+    REQUIRE(r.elapsed.count() > 0);
+  }
+
+  SECTION("HierarchyMerger") {
+    const auto r = runHardTask(files, MergerKind::Hierarchy, /*verbose=*/false);
+    REQUIRE(r.total == 9);
+  }
+
+  SECTION("Both strategies produce identical fingerprints") {
+    const auto a = runHardTask(files, MergerKind::Flat, /*verbose=*/false);
+    const auto b = runHardTask(files, MergerKind::Hierarchy, /*verbose=*/false);
+    REQUIRE(a.total == b.total);
+    REQUIRE(a.first_ts == b.first_ts);
+    REQUIRE(a.last_ts == b.last_ts);
+    REQUIRE(a.fingerprint == b.fingerprint);
+
+    // Correctness anchor: snapshot taken on the (pre-refactor) simdjson
+    // parser. The parser swap (positional byte-reader) must not change the
+    // observable output sequence, so this value must survive every refactor
+    // of the ingestion hot path. If you deliberately change the fingerprint
+    // formula (HardTask.cpp), update this constant in the same commit.
+    constexpr std::uint64_t kExpectedFingerprint = 0x3282568c7ef3caaULL;
+    REQUIRE(a.fingerprint == kExpectedFingerprint);
+  }
+
+  fs::remove_all(dir);
+}
+
+TEST_CASE("runHardTask - empty file list returns zero total", "[HardTask]") {
+  const auto r = runHardTask({}, MergerKind::Flat, false);
+  REQUIRE(r.total == 0);
+}
+
+TEST_CASE("listMboJsonFiles - picks only *.mbo.json files in lexicographic "
+          "order",
+          "[HardTask]") {
+  const fs::path dir = fs::temp_directory_path() / "cmf_hardtask_listing";
+  fs::remove_all(dir);
+  fs::create_directories(dir);
+  {
+    std::ofstream(dir / "z.mbo.json");
+  }
+  {
+    std::ofstream(dir / "a.mbo.json");
+  }
+  {
+    std::ofstream(dir / "m.mbo.json");
+  }
+  {
+    std::ofstream(dir / "metadata.json");
+  } // must be skipped
+  {
+    std::ofstream(dir / "other.txt");
+  }
+
+  const auto files = listMboJsonFiles(dir);
+  REQUIRE(files.size() == 3);
+  REQUIRE(files[0].filename() == "a.mbo.json");
+  REQUIRE(files[1].filename() == "m.mbo.json");
+  REQUIRE(files[2].filename() == "z.mbo.json");
+
+  fs::remove_all(dir);
+}

--- a/test/MappedFileTest.cpp
+++ b/test/MappedFileTest.cpp
@@ -1,0 +1,85 @@
+// Unit tests for MappedFile: open/close, empty file, nonexistent, move
+// semantics.
+
+#include "market_data/MappedFile.hpp"
+
+#include "TempFile.hpp"
+#include "catch2/catch_all.hpp"
+
+#include <cstring>
+#include <fstream>
+#include <stdexcept>
+#include <string>
+
+using namespace cmf;
+
+namespace {
+
+void writeFile(const std::filesystem::path &p, const std::string &contents) {
+  std::ofstream out(p, std::ios::binary);
+  REQUIRE(out.is_open());
+  out.write(contents.data(), static_cast<std::streamsize>(contents.size()));
+}
+
+} // namespace
+
+TEST_CASE("MappedFile - opens and mmaps a regular file", "[MappedFile]") {
+  TempFile tf("mapped_file_basic.bin");
+  const std::string body = "hello world\n";
+  writeFile(tf.getPath(), body);
+
+  MappedFile mf(tf.getPath());
+  REQUIRE(mf.size() == body.size());
+  REQUIRE(mf.data() != nullptr);
+  REQUIRE(std::memcmp(mf.data(), body.data(), body.size()) == 0);
+  REQUIRE(std::string{mf.view()} == body);
+}
+
+TEST_CASE("MappedFile - empty file yields null data and zero size",
+          "[MappedFile]") {
+  TempFile tf("mapped_file_empty.bin");
+  writeFile(tf.getPath(), "");
+
+  MappedFile mf(tf.getPath());
+  REQUIRE(mf.size() == 0);
+  REQUIRE(mf.data() == nullptr);
+}
+
+TEST_CASE("MappedFile - missing file throws", "[MappedFile]") {
+  REQUIRE_THROWS_AS(
+      MappedFile("/tmp/cmf_mapped_file_definitely_does_not_exist_98765.bin"),
+      std::runtime_error);
+}
+
+TEST_CASE("MappedFile - move-construct transfers ownership", "[MappedFile]") {
+  TempFile tf("mapped_file_move.bin");
+  writeFile(tf.getPath(), "data");
+
+  MappedFile a(tf.getPath());
+  const char *orig_ptr = a.data();
+  const std::size_t orig_size = a.size();
+
+  MappedFile b(std::move(a));
+  REQUIRE(b.data() == orig_ptr);
+  REQUIRE(b.size() == orig_size);
+  REQUIRE(a.data() == nullptr);
+  REQUIRE(a.size() == 0);
+}
+
+TEST_CASE("MappedFile - move-assign releases old mapping", "[MappedFile]") {
+  TempFile tf1("mapped_file_src1.bin");
+  TempFile tf2("mapped_file_src2.bin");
+  writeFile(tf1.getPath(), "aaaa");
+  writeFile(tf2.getPath(), "bbbbbbbb");
+
+  MappedFile a(tf1.getPath());
+  MappedFile b(tf2.getPath());
+  REQUIRE(a.size() == 4);
+  REQUIRE(b.size() == 8);
+
+  a = std::move(b);
+  REQUIRE(a.size() == 8);
+  REQUIRE(std::memcmp(a.data(), "bbbbbbbb", 8) == 0);
+  REQUIRE(b.data() == nullptr);
+  REQUIRE(b.size() == 0);
+}

--- a/test/MarketDataEventTest.cpp
+++ b/test/MarketDataEventTest.cpp
@@ -1,0 +1,115 @@
+// Unit tests for MarketDataEvent: enum parsing, defaults, ordering, dump.
+
+#include "market_data/MarketDataEvent.hpp"
+
+#include "catch2/catch_all.hpp"
+
+#include <cmath>
+#include <sstream>
+#include <stdexcept>
+
+using namespace cmf;
+
+TEST_CASE("MarketDataEvent - parseAction maps all documented codes",
+          "[MarketDataEvent]") {
+  REQUIRE(parseAction('A') == MdAction::Add);
+  REQUIRE(parseAction('M') == MdAction::Modify);
+  REQUIRE(parseAction('C') == MdAction::Cancel);
+  REQUIRE(parseAction('R') == MdAction::Clear);
+  REQUIRE(parseAction('T') == MdAction::Trade);
+  REQUIRE(parseAction('F') == MdAction::Fill);
+  REQUIRE(parseAction('N') == MdAction::None);
+  REQUIRE_THROWS_AS(parseAction('X'), std::invalid_argument);
+  REQUIRE_THROWS_AS(parseAction('\0'), std::invalid_argument);
+}
+
+TEST_CASE("MarketDataEvent - parseSide maps all documented codes",
+          "[MarketDataEvent]") {
+  REQUIRE(parseSide('B') == Side::Buy);
+  REQUIRE(parseSide('A') == Side::Sell);
+  REQUIRE(parseSide('N') == Side::None);
+  REQUIRE_THROWS_AS(parseSide('X'), std::invalid_argument);
+}
+
+TEST_CASE("MarketDataEvent - default values", "[MarketDataEvent]") {
+  MarketDataEvent e;
+  REQUIRE(e.ts_recv == 0);
+  REQUIRE(e.ts_event == 0);
+  REQUIRE(e.action == MdAction::None);
+  REQUIRE(e.side == Side::None);
+  REQUIRE(e.order_id == 0);
+  REQUIRE(e.size == 0);
+  REQUIRE(e.price == MarketDataEvent::kUndefPrice);
+  REQUIRE_FALSE(e.priceDefined());
+  REQUIRE(std::isnan(e.priceAsDouble()));
+  REQUIRE(e.symbol.empty());
+}
+
+TEST_CASE("MarketDataEvent - fixed-point price round-trip",
+          "[MarketDataEvent]") {
+  MarketDataEvent e;
+  e.price = 1'157'500'000LL; // "1.157500000"
+  REQUIRE(e.priceDefined());
+  REQUIRE(e.priceAsDouble() == Catch::Approx(1.1575).margin(1e-9));
+
+  e.price = -42'000'000'000LL; // "-42.000000000"
+  REQUIRE(e.priceAsDouble() == Catch::Approx(-42.0).margin(1e-9));
+}
+
+TEST_CASE("MarketDataEvent - ordering by ts_recv primary",
+          "[MarketDataEvent]") {
+  MarketDataEvent a, b;
+  a.ts_recv = 100;
+  b.ts_recv = 200;
+  REQUIRE(a < b);
+  REQUIRE_FALSE(b < a);
+  REQUIRE(b > a);
+  REQUIRE_FALSE(a > b);
+}
+
+TEST_CASE("MarketDataEvent - ordering tie-break by sequence then instrument",
+          "[MarketDataEvent]") {
+  MarketDataEvent a, b;
+  a.ts_recv = b.ts_recv = 100;
+
+  SECTION("sequence tie-break") {
+    a.sequence = 1;
+    b.sequence = 2;
+    REQUIRE(a < b);
+    REQUIRE(b > a);
+  }
+
+  SECTION("instrument_id tie-break when sequence equal") {
+    a.sequence = b.sequence = 5;
+    a.instrument_id = 1;
+    b.instrument_id = 2;
+    REQUIRE(a < b);
+  }
+
+  SECTION("fully equal is neither less nor greater") {
+    REQUIRE_FALSE(a < b);
+    REQUIRE_FALSE(b < a);
+  }
+}
+
+TEST_CASE("MarketDataEvent - operator<< prints key fields",
+          "[MarketDataEvent]") {
+  MarketDataEvent e;
+  e.ts_recv = 1775501588486368500LL;
+  e.order_id = 42;
+  e.side = Side::Buy;
+  e.price = 1'234'500'000LL; // 1.2345 in fixed-point (1e-9 scale)
+  e.size = 10;
+  e.action = MdAction::Add;
+  e.instrument_id = 453;
+  e.symbol = "FCEU";
+
+  std::ostringstream os;
+  os << e;
+  const std::string s = os.str();
+  REQUIRE(s.find("ts_recv=1775501588486368500") != std::string::npos);
+  REQUIRE(s.find("order_id=42") != std::string::npos);
+  REQUIRE(s.find("action=A") != std::string::npos);
+  REQUIRE(s.find("instrument_id=453") != std::string::npos);
+  REQUIRE(s.find("symbol=FCEU") != std::string::npos);
+}

--- a/test/MergerTest.cpp
+++ b/test/MergerTest.cpp
@@ -1,0 +1,195 @@
+// Unit tests for FlatMerger and HierarchyMerger.
+//
+// Both mergers must produce a strictly non-decreasing stream by ts_recv over
+// arbitrary numbers of sources of arbitrary lengths. Tested against the same
+// fixtures to guarantee equivalent output.
+
+#include "market_data/Merger.hpp"
+#include "market_data/EventSource.hpp"
+
+#include "catch2/catch_all.hpp"
+
+#include <algorithm>
+#include <cstdint>
+#include <memory>
+#include <random>
+#include <vector>
+
+using namespace cmf;
+
+namespace {
+
+MarketDataEvent makeEvent(std::int64_t ts_recv, std::uint32_t sequence = 0,
+                          std::uint64_t instrument_id = 0) {
+  MarketDataEvent e;
+  e.ts_recv = ts_recv;
+  e.sequence = sequence;
+  e.instrument_id = instrument_id;
+  return e;
+}
+
+std::vector<std::unique_ptr<VectorEventSource>>
+makeSources(std::vector<std::vector<MarketDataEvent>> streams) {
+  std::vector<std::unique_ptr<VectorEventSource>> srcs;
+  srcs.reserve(streams.size());
+  for (auto &s : streams)
+    srcs.push_back(std::make_unique<VectorEventSource>(std::move(s)));
+  return srcs;
+}
+
+std::vector<IEventSource *>
+asPointers(std::vector<std::unique_ptr<VectorEventSource>> &owned) {
+  std::vector<IEventSource *> out;
+  out.reserve(owned.size());
+  for (auto &u : owned)
+    out.push_back(u.get());
+  return out;
+}
+
+std::vector<std::int64_t> drainTs(IMerger &m) {
+  std::vector<std::int64_t> out;
+  MarketDataEvent e;
+  while (m.next(e))
+    out.push_back(e.ts_recv);
+  return out;
+}
+
+std::vector<std::vector<MarketDataEvent>>
+makeSortedStreams(std::size_t n_sources, std::size_t per_source,
+                  std::uint32_t seed) {
+  std::mt19937 rng{seed};
+  std::uniform_int_distribution<std::int64_t> dist(0, 1'000'000);
+  std::vector<std::vector<MarketDataEvent>> out(n_sources);
+  for (std::size_t i = 0; i < n_sources; ++i) {
+    std::vector<std::int64_t> ts(per_source);
+    for (auto &t : ts)
+      t = dist(rng);
+    std::sort(ts.begin(), ts.end());
+    out[i].reserve(per_source);
+    std::uint32_t seq = 0;
+    for (auto t : ts)
+      out[i].push_back(makeEvent(t, seq++, i));
+  }
+  return out;
+}
+
+std::vector<std::int64_t>
+expectedMergedTs(const std::vector<std::vector<MarketDataEvent>> &streams) {
+  std::vector<std::int64_t> all;
+  for (const auto &s : streams)
+    for (const auto &e : s)
+      all.push_back(e.ts_recv);
+  std::sort(all.begin(), all.end());
+  return all;
+}
+
+} // namespace
+
+// ----- FlatMerger --------------------------------------------------------
+
+TEST_CASE("FlatMerger - zero sources returns false", "[Merger][Flat]") {
+  std::vector<IEventSource *> empty;
+  FlatMerger m(empty);
+  MarketDataEvent e;
+  REQUIRE_FALSE(m.next(e));
+}
+
+TEST_CASE("FlatMerger - single source acts as pass-through", "[Merger][Flat]") {
+  auto owned = makeSources({{makeEvent(10), makeEvent(20), makeEvent(30)}});
+  auto srcs = asPointers(owned);
+  FlatMerger m(srcs);
+  REQUIRE(drainTs(m) == std::vector<std::int64_t>{10, 20, 30});
+}
+
+TEST_CASE("FlatMerger - 3 sources interleaved", "[Merger][Flat]") {
+  auto owned = makeSources({
+      {makeEvent(1), makeEvent(4), makeEvent(7)},
+      {makeEvent(2), makeEvent(5), makeEvent(8)},
+      {makeEvent(3), makeEvent(6), makeEvent(9)},
+  });
+  auto srcs = asPointers(owned);
+  FlatMerger m(srcs);
+  REQUIRE(drainTs(m) == std::vector<std::int64_t>{1, 2, 3, 4, 5, 6, 7, 8, 9});
+}
+
+TEST_CASE("FlatMerger - unequal-length sources", "[Merger][Flat]") {
+  auto owned = makeSources({
+      {makeEvent(1)},
+      {makeEvent(2), makeEvent(3), makeEvent(4), makeEvent(5)},
+      {}, // empty source is legal
+      {makeEvent(6)},
+  });
+  auto srcs = asPointers(owned);
+  FlatMerger m(srcs);
+  REQUIRE(drainTs(m) == std::vector<std::int64_t>{1, 2, 3, 4, 5, 6});
+}
+
+TEST_CASE("FlatMerger - random stress 20 sources x 500 events",
+          "[Merger][Flat]") {
+  auto streams = makeSortedStreams(20, 500, /*seed=*/42);
+  auto expected = expectedMergedTs(streams);
+
+  auto owned = makeSources(std::move(streams));
+  auto srcs = asPointers(owned);
+  FlatMerger m(srcs);
+  REQUIRE(drainTs(m) == expected);
+}
+
+// ----- HierarchyMerger ---------------------------------------------------
+
+TEST_CASE("HierarchyMerger - zero sources returns false",
+          "[Merger][Hierarchy]") {
+  std::vector<IEventSource *> empty;
+  HierarchyMerger m(empty);
+  MarketDataEvent e;
+  REQUIRE_FALSE(m.next(e));
+}
+
+TEST_CASE("HierarchyMerger - single source acts as pass-through",
+          "[Merger][Hierarchy]") {
+  auto owned = makeSources({{makeEvent(10), makeEvent(20), makeEvent(30)}});
+  auto srcs = asPointers(owned);
+  HierarchyMerger m(srcs);
+  REQUIRE(drainTs(m) == std::vector<std::int64_t>{10, 20, 30});
+}
+
+TEST_CASE("HierarchyMerger - N=7 (odd tree) preserves order",
+          "[Merger][Hierarchy]") {
+  auto streams = makeSortedStreams(7, 100, /*seed=*/7);
+  auto expected = expectedMergedTs(streams);
+  auto owned = makeSources(std::move(streams));
+  auto srcs = asPointers(owned);
+  HierarchyMerger m(srcs);
+  REQUIRE(drainTs(m) == expected);
+}
+
+TEST_CASE("HierarchyMerger - random stress 20 sources x 500 events",
+          "[Merger][Hierarchy]") {
+  auto streams = makeSortedStreams(20, 500, /*seed=*/42);
+  auto expected = expectedMergedTs(streams);
+  auto owned = makeSources(std::move(streams));
+  auto srcs = asPointers(owned);
+  HierarchyMerger m(srcs);
+  REQUIRE(drainTs(m) == expected);
+}
+
+// ----- equivalence of both strategies -------------------------------------
+
+TEST_CASE("Flat and Hierarchy mergers produce identical sequences",
+          "[Merger][Equivalence]") {
+  for (std::uint32_t seed : {1u, 2u, 17u, 999u}) {
+    auto streams = makeSortedStreams(16, 250, seed);
+
+    auto ownedA = makeSources(streams);
+    auto srcsA = asPointers(ownedA);
+    FlatMerger flat(srcsA);
+    auto flat_out = drainTs(flat);
+
+    auto ownedB = makeSources(streams);
+    auto srcsB = asPointers(ownedB);
+    HierarchyMerger hier(srcsB);
+    auto hier_out = drainTs(hier);
+
+    REQUIRE(flat_out == hier_out);
+  }
+}

--- a/test/MmapMboSourceTest.cpp
+++ b/test/MmapMboSourceTest.cpp
@@ -1,0 +1,85 @@
+// Integration tests for MmapMboSource on temporary NDJSON files.
+
+#include "market_data/MmapMboSource.hpp"
+
+#include "TempFile.hpp"
+#include "catch2/catch_all.hpp"
+
+#include <fstream>
+#include <stdexcept>
+#include <string>
+
+using namespace cmf;
+
+namespace {
+
+// Real Clear + Add + Cancel lines from XEUR-20260409-HTT6HHLT6R.
+constexpr const char *kLines[] = {
+    R"({"ts_recv":"2026-04-06T18:53:08.486368500Z","hd":{"ts_event":"2026-04-06T18:53:08.486361336Z","rtype":160,"publisher_id":101,"instrument_id":453},"action":"R","side":"N","price":null,"size":0,"channel_id":23,"order_id":"0","flags":128,"ts_in_delta":7164,"sequence":0,"symbol":"FCEU SI 20281218 PS"})",
+    R"({"ts_recv":"2026-04-07T00:00:00.246103535Z","hd":{"ts_event":"2026-04-07T00:00:00.246086711Z","rtype":160,"publisher_id":101,"instrument_id":436},"action":"A","side":"B","price":"1.157500000","size":20,"channel_id":23,"order_id":"10998892037100869125","flags":128,"ts_in_delta":985,"sequence":81255,"symbol":"FCEU SI 20260615 PS"})",
+    R"({"ts_recv":"2026-04-07T00:00:02.399364973Z","hd":{"ts_event":"2026-04-07T00:00:02.399352523Z","rtype":160,"publisher_id":101,"instrument_id":436},"action":"C","side":"B","price":"1.157500000","size":20,"channel_id":23,"order_id":"10998892037100869125","flags":128,"ts_in_delta":882,"sequence":81351,"symbol":"FCEU SI 20260615 PS"})",
+};
+
+void writeFile(const std::filesystem::path &p, const std::string &body) {
+  std::ofstream out(p, std::ios::binary);
+  REQUIRE(out.is_open());
+  out.write(body.data(), static_cast<std::streamsize>(body.size()));
+}
+
+} // namespace
+
+TEST_CASE("MmapMboSource - streams three records in order", "[MmapMboSource]") {
+  TempFile tf("mmap_mbo_source_3.mbo.json");
+  std::string body;
+  for (const char *l : kLines) {
+    body.append(l);
+    body.push_back('\n');
+  }
+  writeFile(tf.getPath(), body);
+
+  MmapMboSource src(tf.getPath());
+  MarketDataEvent e;
+
+  REQUIRE(src.next(e));
+  REQUIRE(e.action == MdAction::Clear);
+  REQUIRE(e.instrument_id == 453);
+
+  REQUIRE(src.next(e));
+  REQUIRE(e.action == MdAction::Add);
+  REQUIRE(e.order_id == 10998892037100869125ULL);
+
+  REQUIRE(src.next(e));
+  REQUIRE(e.action == MdAction::Cancel);
+
+  REQUIRE_FALSE(src.next(e));
+}
+
+TEST_CASE("MmapMboSource - empty file yields zero events", "[MmapMboSource]") {
+  TempFile tf("mmap_mbo_source_empty.mbo.json");
+  writeFile(tf.getPath(), "");
+
+  MmapMboSource src(tf.getPath());
+  MarketDataEvent e;
+  REQUIRE_FALSE(src.next(e));
+}
+
+TEST_CASE("MmapMboSource - file without trailing newline still fully parsed",
+          "[MmapMboSource]") {
+  TempFile tf("mmap_mbo_source_no_nl.mbo.json");
+  // No trailing '\n'.
+  writeFile(tf.getPath(), kLines[0]);
+
+  MmapMboSource src(tf.getPath());
+  MarketDataEvent e;
+  REQUIRE(src.next(e));
+  REQUIRE(e.action == MdAction::Clear);
+  REQUIRE_FALSE(src.next(e));
+}
+
+TEST_CASE("MmapMboSource - rejects file with unexpected prefix",
+          "[MmapMboSource]") {
+  TempFile tf("mmap_mbo_source_bad_prefix.mbo.json");
+  writeFile(tf.getPath(), "this is not a Databento MBO file\n");
+
+  REQUIRE_THROWS_AS(MmapMboSource(tf.getPath()), std::runtime_error);
+}

--- a/test/PositionalMboParserTest.cpp
+++ b/test/PositionalMboParserTest.cpp
@@ -1,0 +1,131 @@
+// Unit tests for PositionalMboParser: identical expectations as the (to be
+// retired) MboJsonParser, driven by real captured lines.
+
+#include "market_data/PositionalMboParser.hpp"
+
+#include "catch2/catch_all.hpp"
+
+#include <cstring>
+#include <string>
+
+using namespace cmf;
+
+// Real line (action='R', price=null) from
+// XEUR-20260409-HTT6HHLT6R/xeur-eobi-20260406.mbo.json, first record.
+constexpr const char *kClearLine =
+    R"JSON({"ts_recv":"2026-04-06T18:53:08.486368500Z","hd":{"ts_event":"2026-04-06T18:53:08.486361336Z","rtype":160,"publisher_id":101,"instrument_id":453},"action":"R","side":"N","price":null,"size":0,"channel_id":23,"order_id":"0","flags":128,"ts_in_delta":7164,"sequence":0,"symbol":"FCEU SI 20281218 PS"})JSON";
+
+// Real line (action='A', side='B', non-null price string) from
+// XEUR-20260409-HTT6HHLT6R/xeur-eobi-20260407.mbo.json.
+constexpr const char *kAddLine =
+    R"JSON({"ts_recv":"2026-04-07T00:00:00.246103535Z","hd":{"ts_event":"2026-04-07T00:00:00.246086711Z","rtype":160,"publisher_id":101,"instrument_id":436},"action":"A","side":"B","price":"1.157500000","size":20,"channel_id":23,"order_id":"10998892037100869125","flags":128,"ts_in_delta":985,"sequence":81255,"symbol":"FCEU SI 20260615 PS"})JSON";
+
+constexpr const char *kCancelLine =
+    R"JSON({"ts_recv":"2026-04-07T00:00:02.399364973Z","hd":{"ts_event":"2026-04-07T00:00:02.399352523Z","rtype":160,"publisher_id":101,"instrument_id":436},"action":"C","side":"B","price":"1.157500000","size":20,"channel_id":23,"order_id":"10998892037100869125","flags":128,"ts_in_delta":882,"sequence":81351,"symbol":"FCEU SI 20260615 PS"})JSON";
+
+namespace {
+
+MarketDataEvent parseOne(const char *line) {
+  const std::size_t n = std::strlen(line);
+  PositionalMboParser p(line, line + n);
+  MarketDataEvent e;
+  REQUIRE(p.next(e));
+  return e;
+}
+
+} // namespace
+
+TEST_CASE("PositionalMboParser - Clear (action=R, price=null)",
+          "[PositionalMboParser]") {
+  const auto e = parseOne(kClearLine);
+
+  REQUIRE(e.ts_recv == 1775501588486368500LL);
+  REQUIRE(e.ts_event == 1775501588486361336LL);
+  REQUIRE(e.rtype == 160);
+  REQUIRE(e.publisher_id == 101);
+  REQUIRE(e.instrument_id == 453);
+  REQUIRE(e.action == MdAction::Clear);
+  REQUIRE(e.side == Side::None);
+  REQUIRE_FALSE(e.priceDefined());
+  REQUIRE(e.price == MarketDataEvent::kUndefPrice);
+  REQUIRE(e.size == 0);
+  REQUIRE(e.channel_id == 23);
+  REQUIRE(e.order_id == 0);
+  REQUIRE(e.flags == 128);
+  REQUIRE(e.ts_in_delta == 7164);
+  REQUIRE(e.sequence == 0);
+  REQUIRE(e.symbol == "FCEU SI 20281218 PS");
+}
+
+TEST_CASE("PositionalMboParser - Add (real Buy-side order)",
+          "[PositionalMboParser]") {
+  const auto e = parseOne(kAddLine);
+
+  REQUIRE(e.action == MdAction::Add);
+  REQUIRE(e.side == Side::Buy);
+  REQUIRE(e.price == 1'157'500'000LL);
+  REQUIRE(e.priceAsDouble() == Catch::Approx(1.1575).margin(1e-9));
+  REQUIRE(e.size == 20);
+  REQUIRE(e.instrument_id == 436);
+  REQUIRE(e.order_id == 10998892037100869125ULL);
+  REQUIRE(e.sequence == 81255);
+  REQUIRE(e.flags == 128);
+  REQUIRE(e.symbol == "FCEU SI 20260615 PS");
+}
+
+TEST_CASE("PositionalMboParser - Cancel (action=C)", "[PositionalMboParser]") {
+  const auto e = parseOne(kCancelLine);
+  REQUIRE(e.action == MdAction::Cancel);
+  REQUIRE(e.side == Side::Buy);
+  REQUIRE(e.price == 1'157'500'000LL);
+  REQUIRE(e.order_id == 10998892037100869125ULL);
+}
+
+TEST_CASE("PositionalMboParser - three records back-to-back in one buffer",
+          "[PositionalMboParser]") {
+  std::string buf;
+  buf.append(kClearLine);
+  buf.push_back('\n');
+  buf.append(kAddLine);
+  buf.push_back('\n');
+  buf.append(kCancelLine);
+  buf.push_back('\n');
+
+  PositionalMboParser p(buf.data(), buf.data() + buf.size());
+  MarketDataEvent e;
+
+  REQUIRE(p.next(e));
+  REQUIRE(e.action == MdAction::Clear);
+  REQUIRE(p.next(e));
+  REQUIRE(e.action == MdAction::Add);
+  REQUIRE(p.next(e));
+  REQUIRE(e.action == MdAction::Cancel);
+  REQUIRE_FALSE(p.next(e));
+}
+
+TEST_CASE("PositionalMboParser - fixed-point price round-trips to double",
+          "[PositionalMboParser]") {
+  const auto e = parseOne(kAddLine);
+  // "1.157500000" -> 1_157_500_000 -> 1.1575 within ~1e-9 double precision.
+  REQUIRE(e.price == 1'157'500'000LL);
+  REQUIRE(static_cast<double>(e.price) / 1e9 ==
+          Catch::Approx(1.1575).margin(1e-9));
+}
+
+TEST_CASE("PositionalMboParser - empty buffer yields no events",
+          "[PositionalMboParser]") {
+  PositionalMboParser p(nullptr, nullptr);
+  MarketDataEvent e;
+  REQUIRE_FALSE(p.next(e));
+}
+
+TEST_CASE("PositionalMboParser - negative price parses to negative fixed-point",
+          "[PositionalMboParser]") {
+  // Synthetic line with a negative spread price. Same layout as real data.
+  const std::string line =
+      R"({"ts_recv":"2026-04-07T00:00:00.000000000Z","hd":{"ts_event":"2026-04-07T00:00:00.000000000Z","rtype":160,"publisher_id":101,"instrument_id":1},"action":"A","side":"B","price":"-1.500000000","size":1,"channel_id":1,"order_id":"1","flags":0,"ts_in_delta":0,"sequence":0,"symbol":"X"})";
+
+  const auto e = parseOne(line.c_str());
+  REQUIRE(e.price == -1'500'000'000LL);
+  REQUIRE(e.priceAsDouble() == Catch::Approx(-1.5).margin(1e-9));
+}

--- a/test/SpscRingQueueTest.cpp
+++ b/test/SpscRingQueueTest.cpp
@@ -1,0 +1,123 @@
+// Unit tests for SpscRingQueue including a 1M thread-race stress test.
+
+#include "market_data/SpscRingQueue.hpp"
+
+#include "catch2/catch_all.hpp"
+
+#include <atomic>
+#include <cstdint>
+#include <stdexcept>
+#include <thread>
+#include <vector>
+
+using namespace cmf;
+
+TEST_CASE("SpscRingQueue - capacity rounds up to next power of two",
+          "[SpscRingQueue]") {
+  REQUIRE(SpscRingQueue<int>(1).capacity() == 2);
+  REQUIRE(SpscRingQueue<int>(2).capacity() == 2);
+  REQUIRE(SpscRingQueue<int>(3).capacity() == 4);
+  REQUIRE(SpscRingQueue<int>(5).capacity() == 8);
+  REQUIRE(SpscRingQueue<int>(1000).capacity() == 1024);
+}
+
+TEST_CASE("SpscRingQueue - rejects zero capacity", "[SpscRingQueue]") {
+  REQUIRE_THROWS_AS(SpscRingQueue<int>(0), std::invalid_argument);
+}
+
+TEST_CASE("SpscRingQueue - single-threaded push/pop in order",
+          "[SpscRingQueue]") {
+  SpscRingQueue<int> q(8);
+  for (int i = 0; i < 8; ++i)
+    REQUIRE(q.push(i));
+
+  REQUIRE_FALSE(q.push(99)); // full
+
+  int out = -1;
+  for (int i = 0; i < 8; ++i) {
+    REQUIRE(q.pop(out));
+    REQUIRE(out == i);
+  }
+  REQUIRE_FALSE(q.pop(out));
+  REQUIRE(q.empty());
+}
+
+TEST_CASE("SpscRingQueue - wraparound after partial drain", "[SpscRingQueue]") {
+  SpscRingQueue<int> q(4);
+  REQUIRE(q.push(1));
+  REQUIRE(q.push(2));
+  REQUIRE(q.push(3));
+
+  int out = 0;
+  REQUIRE(q.pop(out));
+  REQUIRE(out == 1);
+  REQUIRE(q.pop(out));
+  REQUIRE(out == 2);
+
+  // Now indices 0..1 freed; push should wrap.
+  REQUIRE(q.push(4));
+  REQUIRE(q.push(5));
+  REQUIRE(q.push(6));
+  REQUIRE_FALSE(q.push(7)); // full again
+
+  int expected = 3;
+  while (q.pop(out))
+    REQUIRE(out == expected++);
+  REQUIRE(expected == 7);
+}
+
+TEST_CASE("SpscRingQueue - close/done semantics", "[SpscRingQueue]") {
+  SpscRingQueue<int> q(4);
+  REQUIRE_FALSE(q.isClosed());
+  REQUIRE_FALSE(q.done());
+
+  REQUIRE(q.push(1));
+  q.close();
+  REQUIRE(q.isClosed());
+  REQUIRE_FALSE(q.done()); // still has 1 item
+
+  int out = 0;
+  REQUIRE(q.pop(out));
+  REQUIRE(out == 1);
+  REQUIRE(q.done());
+}
+
+TEST_CASE("SpscRingQueue - 1M element producer/consumer race preserves order",
+          "[SpscRingQueue][thread]") {
+  constexpr std::uint64_t kN = 1'000'000;
+  SpscRingQueue<std::uint64_t> q(1024);
+
+  std::atomic<std::uint64_t> sum_seen{0};
+  std::atomic<bool> order_ok{true};
+
+  std::thread consumer([&] {
+    std::uint64_t expected = 0;
+    std::uint64_t got = 0;
+    while (expected < kN) {
+      if (q.pop(got)) {
+        if (got != expected) {
+          order_ok.store(false, std::memory_order_relaxed);
+          break;
+        }
+        sum_seen.fetch_add(got, std::memory_order_relaxed);
+        ++expected;
+      } else {
+        std::this_thread::yield();
+      }
+    }
+  });
+
+  for (std::uint64_t i = 0; i < kN; ++i) {
+    while (!q.push(i))
+      std::this_thread::yield();
+  }
+  q.close();
+
+  consumer.join();
+
+  REQUIRE(order_ok.load());
+  // 0 + 1 + ... + (kN-1)
+  const std::uint64_t expected_sum = kN * (kN - 1) / 2;
+  REQUIRE(sum_seen.load() == expected_sum);
+  REQUIRE(q.done());
+}

--- a/test/TimestampParserTest.cpp
+++ b/test/TimestampParserTest.cpp
@@ -1,0 +1,64 @@
+// Unit tests for TimestampParser: Databento pretty_ts ISO 8601 -> NanoTime.
+
+#include "market_data/TimestampParser.hpp"
+
+#include "catch2/catch_all.hpp"
+
+#include <stdexcept>
+#include <string>
+
+using namespace cmf;
+
+TEST_CASE("TimestampParser - epoch", "[TimestampParser]") {
+  REQUIRE(parseDatabentoTimestamp("1970-01-01T00:00:00.000000000Z") == 0);
+}
+
+TEST_CASE("TimestampParser - real Databento sample from 2026-04-06",
+          "[TimestampParser]") {
+  // Ground truth computed independently:
+  //   datetime(2026,4,6,18,53,8,tzinfo=timezone.utc).timestamp()*1e9 +
+  //   486368500 = 1775501588486368500
+  REQUIRE(parseDatabentoTimestamp("2026-04-06T18:53:08.486368500Z") ==
+          1775501588486368500LL);
+}
+
+TEST_CASE("TimestampParser - leap-year Feb 29 -> Mar 1 is 86400 s apart",
+          "[TimestampParser]") {
+  const auto a = parseDatabentoTimestamp("2024-02-29T00:00:00.000000000Z");
+  const auto b = parseDatabentoTimestamp("2024-03-01T00:00:00.000000000Z");
+  REQUIRE(b - a == 86'400'000'000'000LL);
+}
+
+TEST_CASE("TimestampParser - nanosecond resolution", "[TimestampParser]") {
+  const auto a = parseDatabentoTimestamp("2026-04-06T18:53:08.000000000Z");
+  const auto b = parseDatabentoTimestamp("2026-04-06T18:53:08.000000001Z");
+  REQUIRE(b - a == 1);
+}
+
+TEST_CASE("TimestampParser - monotonic across day boundary",
+          "[TimestampParser]") {
+  const auto a = parseDatabentoTimestamp("2026-04-06T23:59:59.999999999Z");
+  const auto b = parseDatabentoTimestamp("2026-04-07T00:00:00.000000000Z");
+  REQUIRE(b == a + 1);
+}
+
+TEST_CASE("TimestampParser - malformed input rejected", "[TimestampParser]") {
+  REQUIRE_THROWS_AS(parseDatabentoTimestamp(""), std::invalid_argument);
+  REQUIRE_THROWS_AS(parseDatabentoTimestamp("not a timestamp"),
+                    std::invalid_argument);
+  // Wrong length (missing trailing Z):
+  REQUIRE_THROWS_AS(parseDatabentoTimestamp("2026-04-06T18:53:08.486368500"),
+                    std::invalid_argument);
+  // Missing T separator:
+  REQUIRE_THROWS_AS(parseDatabentoTimestamp("2026-04-06 18:53:08.486368500Z"),
+                    std::invalid_argument);
+  // Non-digit in field:
+  REQUIRE_THROWS_AS(parseDatabentoTimestamp("2026-04-06T1X:53:08.486368500Z"),
+                    std::invalid_argument);
+  // Out-of-range month:
+  REQUIRE_THROWS_AS(parseDatabentoTimestamp("2026-13-06T18:53:08.486368500Z"),
+                    std::invalid_argument);
+  // Out-of-range hour:
+  REQUIRE_THROWS_AS(parseDatabentoTimestamp("2026-04-06T24:00:00.000000000Z"),
+                    std::invalid_argument);
+}


### PR DESCRIPTION
# Task 1: Data Ingestion Layer

## Summary

Implements the Task 1 data-ingestion layer for the back-tester

## Task coverage

**Standard task.** `back-tester <file.mbo.json>` parses the NDJSON line by line, creates a `MarketDataEvent` for every record, and routes each through `processMarketDataEvent(const MarketDataEvent&)` — the exact signature required by the spec, printing timestamp, `order_id`, `side`, `price`, `size`, `action`. At EOF it prints the summary (total, first/last `ts_recv`) and the first 10 and last 10 events.

**Hard task.** `back-tester <dir>` spawns **one `FileProducer` thread per file** (parsing runs in parallel), connects each producer to a lock-free SPSC ring queue, and drains the merged stream from a **dedicated dispatcher thread** that invokes `processMarketDataEvent`. Two merge strategies are implemented and selectable at runtime:

- **Flat Merger** — single-level k-way min-heap across per-file heads (`FlatMerger`, `Merger.cpp`).
- **Hierarchy Merger** — bottom-up binary tree of pair-wise mergers (`HierarchyMerger` + `PairNode`, `Merger.cpp`).

**Perfect global chronological order** is enforced two ways: the dispatcher throws on `ts_recv < prev_ts`, and an FNV-1a-64 fingerprint over `(ts_recv, instrument_id, order_id, sequence)` must match between Flat and Hierarchy — cross-checked automatically at `--strategy=both`. The same `FileProducer` threads are reused unchanged across both strategies.

## Implementation highlights

- **Zero-JSON, zero-allocation hot path.** The parser jumps fixed byte offsets matching Databento's `pretty_px=true`, `pretty_ts=true` layout. No `std::stod`, `std::stoull`, or `std::getline` per record; prices are decoded via two integer reads into `int64` fixed-point.
- **mmap + `MADV_SEQUENTIAL`.** Each file is memory-mapped once; the kernel prefetches pages aggressively for the forward scan.
- **Lock-free producer→dispatcher channel.** `SpscRingQueue<MarketDataEvent>` is bounded, cache-line-padded to eliminate false sharing between `head_` / `tail_`, uses acquire/release ordering, and has a power-of-two capacity for mask-based indexing.
- **Safety guard.** `MmapMboSource` validates the first 12 bytes equal `{"ts_recv":"` on open; any feed-format drift becomes a loud runtime error instead of silent garbage.
- **Error propagation across threads.** Producers capture exceptions via `std::exception_ptr`; the dispatcher does the same. Both are re-thrown on the main thread after all threads join.

## How to build and run

```bash
cmake -B build -S .
cmake --build build -j

# Unit tests (all 51 cases green in Release and under ASan/UBSan)
ctest --test-dir build --output-on-failure

# Standard task — single file
build/bin/back-tester path/to/file.mbo.json

# Hard task — folder, both merge strategies with automatic cross-check
build/bin/back-tester path/to/dir --strategy=both

# Benchmark runner — 3 measured runs with a discarded warmup, reports
# min / median / max throughput per strategy.
scripts/run_benchmark.sh path/to/dir --runs=3 --warmup
```

Additional Hard-task flags:
- `--strategy={flat|hierarchy|both}` — which merger(s) to run (default: `both`).
- `--verbose` — pass every dispatched event through `processMarketDataEvent` (prints; slows throughput).

## Benchmark results

**Dataset:** `XEUR-20260409-HTT6HHLT6R` — 22 `*.mbo.json` files, ~5 GB, **19 869 718** events total.
**Platform:** Apple Silicon MacBook Pro, AppleClang 17, Release (`-O3 -DNDEBUG`).
**Command:** `scripts/run_benchmark.sh <dir> --runs=3 --warmup`.

As requested by the task (total messages / wall-clock / throughput):

| Strategy           | Total messages processed | Wall-clock time (median, s) | Throughput (median, msg/s) |
| ------------------ | -----------------------: | --------------------------: | -------------------------: |
| **Flat Merger**      |               19 869 718 |                       2.345 |              **~7 600 000** |
| **Hierarchy Merger** |               19 869 718 |                       2.606 |              **~6 600 000** |

Full distribution over the three measured runs:

| Strategy   |     min msg/s | median msg/s |     max msg/s |
| ---------- | ------------: | -----------: | ------------: |
| Flat       |     3 510 231 |    6 605 812 |     8 858 919 |
| Hierarchy  |     5 281 044 |    6 595 740 |     8 670 807 |

Run-to-run spread is driven by Apple Silicon thermal throttling under back-to-back loads; the warmup run prefills the page cache and is discarded from the statistics.

### Correctness

- `total == wc -l` over all 22 files → **19 869 718** ✓
- FNV-1a-64 fingerprint over the dispatched stream is `0x6953f24c15939cf5` for **both** Flat and Hierarchy across all runs → emissions are byte-identical.
- Runtime chronology check (`event.ts_recv ≥ prev_ts`) never fires on real data.
- All 51 test cases pass in Release and under `-fsanitize=address,undefined`.

## Testing

51 test cases covering each component. Notable invariants:

- **Hard-coded fingerprint anchor** (`test/HardTaskTest.cpp`): `0x3282568c7ef3caa` on a 3-file synthetic fixture — regression guard for any future change to parser, merger, or dispatcher.
- **1M-element producer/consumer race** (`test/SpscRingQueueTest.cpp`): two threads cross-drain 1 000 000 elements; order and checksum verified — the empirical proof that the lock-free queue's memory ordering is correct.
- **Flat ≡ Hierarchy equivalence** (`test/MergerTest.cpp`): across 4 random seeds × 16 sources × 250 events, both merger outputs are byte-identical.
- **Real captured JSON records** (`test/PositionalMboParserTest.cpp`): Clear / Add / Cancel lines from the actual dataset validate all 14 parsed fields end-to-end.
- **`MappedFile` edge cases**: empty files, missing files, move semantics — covered.
- **Build works clean under ASan + UBSan** — verified via an out-of-source Debug build with sanitizer flags.

## Key new files

| Layer | Files |
| --- | --- |
| Event model | `src/market_data/MarketDataEvent.{hpp,cpp}`, `src/market_data/TimestampParser.{hpp,cpp}` |
| I/O + parsing | `src/market_data/MappedFile.{hpp,cpp}`, `src/market_data/PositionalMboParser.{hpp,cpp}`, `src/market_data/MmapMboSource.{hpp,cpp}` |
| Concurrency primitives | `src/market_data/SpscRingQueue.hpp`, `src/market_data/EventSource.hpp`, `src/market_data/FileProducer.{hpp,cpp}` |
| Mergers | `src/market_data/Merger.{hpp,cpp}` (FlatMerger + HierarchyMerger) |
| Orchestration | `src/market_data/Consumer.{hpp,cpp}`, `src/market_data/HardTask.{hpp,cpp}`, `src/main/main.cpp` |
| Tests | `test/{MarketDataEvent,TimestampParser,MappedFile,PositionalMboParser,MmapMboSource,SpscRingQueue,Merger,HardTask,Consumer}Test.cpp` |
| Tooling | `scripts/run_benchmark.sh` |
