### PR TITLE
Implement LOB actions and snapshots for standard variant (Samsonov V.)

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,2 +1,3 @@
 add_subdirectory(common)
 add_subdirectory(main)
+add_subdirectory(ingestion)

--- a/src/common/BasicTypes.hpp
+++ b/src/common/BasicTypes.hpp
@@ -22,8 +22,10 @@ using MarketId = std::uint16_t;   // identifies a market/exchange
 using SecurityId =
     std::uint16_t; // identifies fungible security traded on 1 or more exchanges
 
-using Quantity = double;
-using Price = double;
+using Price = std::int64_t;
+using Quantity = std::int64_t;
+
+inline constexpr Price PriceScale = 1000000000LL;
 
 enum class Side : signed short
 {

--- a/src/common/LimitOrderBook.cpp
+++ b/src/common/LimitOrderBook.cpp
@@ -1,0 +1,246 @@
+#include "LimitOrderBook.hpp"
+#include "PriceUtils.hpp"
+
+
+#include <iostream>
+#include <stdexcept>
+
+namespace cmf {
+
+void LimitOrderBook::apply(const MarketDataEvent& event) {
+    if (event.action == 'A') {
+        onAdd(event);
+    } else if (event.action == 'C') {
+        onCancel(event);
+    } else if (event.action == 'M') {
+        onModify(event);
+    } else if (event.action == 'T') {
+        onTrade(event);
+    } else if (event.action == 'F') {
+        onFill(event);
+    }
+}
+
+void LimitOrderBook::onAdd(const MarketDataEvent& event) {
+    if (event.order_id == 0) {
+        throw std::runtime_error("Add event has zero order_id");
+    }
+
+    OrderState state;
+    state.orderId = event.order_id;
+    state.instrumentId = event.instrument_id;
+    state.price = event.price;  // уже scaled integer Price
+    state.qty = static_cast<Quantity>(event.size);
+
+    if (event.side == Side::Buy) {
+        state.side = Side::Buy;
+    } else if (event.side == Side::Sell) {
+        state.side = Side::Sell;
+    } else {
+        throw std::runtime_error("Add event has unknown side");
+    }
+
+    orders_[state.orderId] = state;
+
+    if (state.side == Side::Buy) {
+        bids_[state.price] += state.qty;
+    } else {
+        asks_[state.price] += state.qty;
+    }
+}
+
+
+void LimitOrderBook::onCancel(const MarketDataEvent& event) {
+    if (event.order_id == 0) {
+        throw std::runtime_error("Cancel event has zero order_id");
+    }
+
+    auto orderIt = orders_.find(event.order_id);
+    if (orderIt == orders_.end()) {
+        return;
+    }
+
+    OrderState& state = orderIt->second;
+
+    Quantity cancelQty = static_cast<Quantity>(event.size);
+    if (cancelQty <= 0) {
+        return;
+    }
+    if (cancelQty > state.qty) {
+        cancelQty = state.qty;
+    }
+
+    if (state.side == Side::Buy) {
+        auto levelIt = bids_.find(state.price);
+        if (levelIt != bids_.end()) {
+            levelIt->second -= cancelQty;
+            if (levelIt->second <= 0) {
+                bids_.erase(levelIt);
+            }
+        }
+    } else if (state.side == Side::Sell) {
+        auto levelIt = asks_.find(state.price);
+        if (levelIt != asks_.end()) {
+            levelIt->second -= cancelQty;
+            if (levelIt->second <= 0) {
+                asks_.erase(levelIt);
+            }
+        }
+    }
+
+    state.qty -= cancelQty;
+    if (state.qty <= 0) {
+        orders_.erase(orderIt);
+    }
+}
+
+void LimitOrderBook::onModify(const MarketDataEvent& event) {
+    if (event.order_id == 0) {
+        throw std::runtime_error("Modify event has zero order_id");
+    }
+
+    auto orderIt = orders_.find(event.order_id);
+    if (orderIt == orders_.end()) {
+        return;
+    }
+
+    OrderState& state = orderIt->second;
+
+    if (state.side == Side::Buy) {
+        auto levelIt = bids_.find(state.price);
+        if (levelIt != bids_.end()) {
+            levelIt->second -= state.qty;
+            if (levelIt->second <= 0) {
+                bids_.erase(levelIt);
+            }
+        }
+    } else if (state.side == Side::Sell) {
+        auto levelIt = asks_.find(state.price);
+        if (levelIt != asks_.end()) {
+            levelIt->second -= state.qty;
+            if (levelIt->second <= 0) {
+                asks_.erase(levelIt);
+            }
+        }
+    }
+
+    if (event.price > 0) {
+        state.price = event.price;
+    }
+
+    if (event.size > 0) {
+        state.qty = static_cast<Quantity>(event.size);
+    }
+
+    if (event.side == Side::Buy || event.side == Side::Sell) {
+        state.side = event.side;
+    }
+
+    if (state.side == Side::Buy) {
+        bids_[state.price] += state.qty;
+    } else if (state.side == Side::Sell) {
+        asks_[state.price] += state.qty;
+    }
+}
+
+void LimitOrderBook::reduceOrder(OrderId orderId, Quantity executedQty) {
+    if (orderId == 0 || executedQty <= 0) {
+        return;
+    }
+
+    auto orderIt = orders_.find(orderId);
+    if (orderIt == orders_.end()) {
+        return;
+    }
+
+    OrderState& state = orderIt->second;
+
+    Quantity reduction = std::min(state.qty, executedQty);
+
+    if (state.side == Side::Buy) {
+        auto levelIt = bids_.find(state.price);
+        if (levelIt != bids_.end()) {
+            levelIt->second -= reduction;
+            if (levelIt->second <= 0) {
+                bids_.erase(levelIt);
+            }
+        }
+    } else if (state.side == Side::Sell) {
+        auto levelIt = asks_.find(state.price);
+        if (levelIt != asks_.end()) {
+            levelIt->second -= reduction;
+            if (levelIt->second <= 0) {
+                asks_.erase(levelIt);
+            }
+        }
+    }
+
+    state.qty -= reduction;
+
+    if (state.qty <= 0) {
+        orders_.erase(orderIt);
+    }
+}
+
+void LimitOrderBook::onTrade(const MarketDataEvent& event) {
+    ++trade_count_;
+    trade_volume_ += static_cast<Quantity>(event.size);
+}
+
+void LimitOrderBook::onFill(const MarketDataEvent& event) {
+    if (event.order_id == 0) {
+        return;
+    }
+
+    reduceOrder(event.order_id, static_cast<Quantity>(event.size));
+}
+
+std::optional<std::pair<Price, Quantity>> LimitOrderBook::bestBid() const {
+    if (bids_.empty()) {
+        return std::nullopt;
+    }
+
+    return *bids_.begin();
+}
+
+std::optional<std::pair<Price, Quantity>> LimitOrderBook::bestAsk() const {
+    if (asks_.empty()) {
+        return std::nullopt;
+    }
+
+    return *asks_.begin();
+}
+
+Quantity LimitOrderBook::volumeAtPrice(Side side, Price price) const {
+    if (side == Side::Buy) {
+        auto it = bids_.find(price);
+        return (it != bids_.end()) ? it->second : 0;
+    }
+
+    if (side == Side::Sell) {
+        auto it = asks_.find(price);
+        return (it != asks_.end()) ? it->second : 0;
+    }
+
+    return 0;
+}
+
+void LimitOrderBook::printSnapshot(std::size_t depth) const {
+    std::cout << "----- LOB Snapshot -----\n";
+
+    std::cout << "ASKS:\n";
+    std::size_t askCount = 0;
+    for (auto it = asks_.begin(); it != asks_.end() && askCount < depth; ++it, ++askCount) {
+        std::cout << "price=" << formatScaledPrice(it->first)
+                  << " qty=" << it->second << "\n";
+    }
+
+    std::cout << "BIDS:\n";
+    std::size_t bidCount = 0;
+    for (auto it = bids_.begin(); it != bids_.end() && bidCount < depth; ++it, ++bidCount) {
+        std::cout << "price=" << formatScaledPrice(it->first)
+                  << " qty=" << it->second << "\n";
+    }
+}
+
+} // namespace cmf

--- a/src/common/LimitOrderBook.hpp
+++ b/src/common/LimitOrderBook.hpp
@@ -1,0 +1,47 @@
+#pragma once
+
+
+#include <cstddef>
+#include <map>
+#include <optional>
+#include <unordered_map>
+#include <utility>
+
+#include "BasicTypes.hpp"
+#include "MarketDataEvent.hpp"
+#include "OrderState.hpp"
+
+
+namespace cmf {
+
+class LimitOrderBook {
+public:
+    void apply(const MarketDataEvent& event); // this method does change the object
+
+    std::optional<std::pair<Price, Quantity>> bestBid() const; // const here not to change objects
+    std::optional<std::pair<Price, Quantity>> bestAsk() const;
+
+    Quantity volumeAtPrice(Side side, Price price) const;
+    void printSnapshot(std::size_t depth = 5) const;
+
+    std::uint64_t tradeCount() const { return trade_count_; }
+    Quantity tradeVolume() const { return trade_volume_; }
+
+private:
+    void onAdd(const MarketDataEvent& event);
+    void onCancel(const MarketDataEvent& event);
+    void onModify(const MarketDataEvent& event);
+    void onTrade(const MarketDataEvent& event);
+    void onFill(const MarketDataEvent& event);
+    void reduceOrder(OrderId orderId, Quantity executedQty);
+
+    std::unordered_map<OrderId, OrderState> orders_;
+
+    std::map<Price, Quantity, std::greater<Price>> bids_;
+    std::map<Price, Quantity> asks_;
+
+    std::uint64_t trade_count_ = 0;
+    Quantity trade_volume_ = 0;
+};
+
+} // namespace cmf

--- a/src/common/MarketDataEvent.hpp
+++ b/src/common/MarketDataEvent.hpp
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <cstdint>
+#include "BasicTypes.hpp"
+
+namespace cmf {
+
+using RType = std::uint8_t;
+using Flags = std::uint8_t;
+using Action = char;
+
+
+struct MarketDataEvent {
+    NanoTime ts_recv = 0;
+    NanoTime ts_event = 0;
+
+    RType rtype = 0;
+    std::uint32_t publisher_id = 0;
+    std::uint32_t instrument_id = 0;
+
+    Action action = 'N';
+    Side side = Side::None;
+
+    Price price = 0;           // scaled integer with PriceScale
+    std::uint32_t size = 0;
+
+    std::uint16_t channel_id = 0;
+    OrderId order_id = 0;
+
+    Flags flags = 0;
+    std::int32_t ts_in_delta = 0;
+    std::uint32_t sequence = 0;
+};
+
+} // namespace cmf

--- a/src/common/OrderState.hpp
+++ b/src/common/OrderState.hpp
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "BasicTypes.hpp"
+
+namespace cmf {
+
+
+struct OrderState {
+    OrderId orderId = 0;
+    std::uint32_t instrumentId = 0;
+    Side side = Side::None;
+    Price price = 0;
+    Quantity qty = 0;
+};
+
+} // namespace cmf
+
+
+

--- a/src/common/PriceUtils.hpp
+++ b/src/common/PriceUtils.hpp
@@ -1,0 +1,74 @@
+#pragma once
+
+#include <cctype>
+#include <cstdint>
+#include <iomanip>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+
+#include "BasicTypes.hpp"
+
+namespace cmf {
+
+inline Price parseScaledPrice(const std::string& s) {
+    if (s.empty()) {
+        throw std::runtime_error("Empty price string");
+    }
+
+    bool negative = false;
+    std::size_t i = 0;
+
+    if (s[i] == '-') {
+        negative = true;
+        ++i;
+    }
+
+    std::int64_t integerPart = 0;
+    while (i < s.size() && std::isdigit(static_cast<unsigned char>(s[i]))) {
+        integerPart = integerPart * 10 + (s[i] - '0');
+        ++i;
+    }
+
+    std::int64_t fractionalPart = 0;
+    std::int64_t fractionalScale = 1;
+
+    if (i < s.size() && s[i] == '.') {
+        ++i;
+        while (i < s.size() && std::isdigit(static_cast<unsigned char>(s[i]))) {
+            if (fractionalScale < PriceScale) {
+                fractionalPart = fractionalPart * 10 + (s[i] - '0');
+                fractionalScale *= 10;
+            }
+            ++i;
+        }
+    }
+
+    while (fractionalScale < PriceScale) {
+        fractionalPart *= 10;
+        fractionalScale *= 10;
+    }
+
+    std::int64_t result = integerPart * PriceScale + fractionalPart;
+    return negative ? -result : result;
+}
+
+inline std::string formatScaledPrice(Price price) {
+    bool negative = price < 0;
+    std::int64_t absPrice = negative ? -price : price;
+
+    std::int64_t integerPart = absPrice / PriceScale;
+    std::int64_t fractionalPart = absPrice % PriceScale;
+
+    std::ostringstream oss;
+    if (negative) {
+        oss << '-';
+    }
+
+    oss << integerPart << '.'
+        << std::setw(9) << std::setfill('0') << fractionalPart;
+
+    return oss.str();
+}
+
+} // namespace cmf

--- a/src/ingestion/CMakeLists.txt
+++ b/src/ingestion/CMakeLists.txt
@@ -1,0 +1,11 @@
+set(TARGET back-tester-ingestion)
+
+file(GLOB SRC CONFIGURE_DEPENDS *.cpp)
+
+add_library(${TARGET} STATIC ${SRC})
+add_dependencies(${TARGET} GenerateVersion)
+
+target_include_directories(${TARGET} PUBLIC
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    ${PROJECT_SOURCE_DIR}/src
+)

--- a/src/ingestion/SimpleDataParser.cpp
+++ b/src/ingestion/SimpleDataParser.cpp
@@ -1,0 +1,208 @@
+#include "SimpleDataParser.hpp"
+
+#include <cstdio>
+#include <cstring>
+#include <fstream>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+
+#include "common/BasicTypes.hpp"
+
+namespace cmf {
+
+static std::string_view findValue(std::string_view line, std::string_view key) {
+    std::string needle;
+    needle.reserve(key.size() + 3);
+    needle += '"';
+    needle += key;
+    needle += '"';
+    needle += ':';
+
+    auto pos = line.find(needle);
+    if (pos == std::string_view::npos)
+        return {};
+
+    std::string_view rest = line.substr(pos + needle.size());
+    while (!rest.empty() && rest.front() == ' ')
+        rest.remove_prefix(1);
+
+    return rest;
+}
+
+static std::optional<std::string> getString(std::string_view line,
+                                            std::string_view key) {
+    auto rest = findValue(line, key);
+    if (rest.empty() || rest.front() != '"')
+        return std::nullopt;
+    rest.remove_prefix(1);
+    auto end = rest.find('"');
+    if (end == std::string_view::npos)
+        return std::nullopt;
+    return std::string(rest.substr(0, end));
+}
+
+static std::optional<std::string> getNumericRaw(std::string_view line,
+                                                std::string_view key) {
+    auto rest = findValue(line, key);
+    if (rest.empty())
+        return std::nullopt;
+    if (rest.front() != '-' && (rest.front() < '0' || rest.front() > '9'))
+        return std::nullopt;
+    std::size_t len = 0;
+    while (len < rest.size() &&
+           (rest[len] == '-' || (rest[len] >= '0' && rest[len] <= '9')))
+        ++len;
+    return std::string(rest.substr(0, len));
+}
+
+static std::string_view getObject(std::string_view line, std::string_view key) {
+    auto rest = findValue(line, key);
+    if (rest.empty() || rest.front() != '{')
+        return {};
+    std::size_t depth = 0;
+    std::size_t len = 0;
+    for (std::size_t i = 0; i < rest.size(); ++i) {
+        if (rest[i] == '{')
+            ++depth;
+        else if (rest[i] == '}') {
+            --depth;
+            if (depth == 0) {
+                len = i + 1;
+                break;
+            }
+        }
+    }
+    return rest.substr(0, len);
+}
+
+static bool isNull(std::string_view line, std::string_view key) {
+    auto rest = findValue(line, key);
+    return rest.size() >= 4 && rest.substr(0, 4) == "null";
+}
+
+static NanoTime parseIso8601Nanos(const std::string& s) {
+    static constexpr std::int64_t POW10[10] = {
+        1'000'000'000LL, 100'000'000LL, 10'000'000LL, 1'000'000LL, 100'000LL,
+        10'000LL,        1'000LL,       100LL,        10LL,        1LL};
+
+    std::tm tm{};
+    const char* p = strptime(s.c_str(), "%Y-%m-%dT%H:%M:%S", &tm);
+    if (!p)
+        throw std::runtime_error("bad timestamp: " + s);
+
+    time_t sec = timegm(&tm);
+    std::int64_t nanos = 0;
+
+    if (*p == '.') {
+        ++p;
+        int digits = 0;
+        while (*p >= '0' && *p <= '9' && digits < 9) {
+            nanos = nanos * 10 + (*p++ - '0');
+            ++digits;
+        }
+        nanos *= POW10[digits];
+    }
+
+    return static_cast<NanoTime>(sec) * 1'000'000'000LL + nanos;
+}
+
+static MarketDataEvent parseLine(const std::string& line) {
+    MarketDataEvent e;
+
+    std::string_view sv(line);
+
+    auto hd = getObject(sv, "hd");
+
+    auto tsRecv = getString(sv, "ts_recv");
+    if (!tsRecv)
+        throw std::runtime_error("missing ts_recv");
+    e.ts_recv = parseIso8601Nanos(*tsRecv);
+
+    auto tsEvent = getString(hd, "ts_event");
+    if (tsEvent)
+        e.ts_event = parseIso8601Nanos(*tsEvent);
+
+    auto rtype = getNumericRaw(hd, "rtype");
+    if (rtype)
+        e.rtype = static_cast<RType>(std::stoul(*rtype));
+
+    auto pubId = getNumericRaw(hd, "publisher_id");
+    if (pubId)
+        e.publisher_id = static_cast<std::uint32_t>(std::stoul(*pubId));
+
+    auto instId = getNumericRaw(hd, "instrument_id");
+    if (instId)
+        e.instrument_id = static_cast<std::uint32_t>(std::stoul(*instId));
+
+    auto action = getString(sv, "action");
+    if (action && !action->empty())
+        e.action = (*action)[0];
+
+    auto sideStr = getString(sv, "side");
+    if (sideStr && !sideStr->empty()) {
+        char c = (*sideStr)[0];
+        if (c == 'B')
+            e.side = Side::Buy;
+        else if (c == 'A' || c == 'S')
+            e.side = Side::Sell;
+        else
+            e.side = Side::None;
+    }
+
+    if (!isNull(sv, "price")) {
+        auto priceStr = getString(sv, "price");
+        if (priceStr) {
+            // double → scaled integer by PriceScale
+            double p = std::stod(*priceStr);
+            e.price = static_cast<Price>(p * static_cast<double>(PriceScale));
+        }
+    }
+
+    auto size = getNumericRaw(sv, "size");
+    if (size)
+        e.size = static_cast<std::uint32_t>(std::stoul(*size));
+
+    auto chanId = getNumericRaw(sv, "channel_id");
+    if (chanId)
+        e.channel_id = static_cast<std::uint16_t>(std::stoul(*chanId));
+
+    auto orderId = getString(sv, "order_id");
+    if (orderId)
+        e.order_id = std::stoull(*orderId);
+
+    auto flags = getNumericRaw(sv, "flags");
+    if (flags)
+        e.flags = static_cast<Flags>(std::stoul(*flags));
+
+    auto delta = getNumericRaw(sv, "ts_in_delta");
+    if (delta)
+        e.ts_in_delta = static_cast<std::int32_t>(std::stol(*delta));
+
+    auto seq = getNumericRaw(sv, "sequence");
+    if (seq)
+        e.sequence = static_cast<std::uint32_t>(std::stoul(*seq));
+
+    return e;
+}
+
+void SimpleDataParser::parse_inner(
+    const std::function<void(const MarketDataEvent&)>& f) const {
+    std::ifstream fs(path_);
+    if (!fs.is_open())
+        throw std::runtime_error("SimpleDataParser: cannot open " + path_.string());
+
+    std::string line;
+    while (std::getline(fs, line)) {
+        if (line.empty())
+            continue;
+        try {
+            f(parseLine(line));
+        } catch (const std::exception& ex) {
+            std::fprintf(stderr, "SimpleDataParser: skipping line: %s\n", ex.what());
+        }
+    }
+}
+
+} // namespace cmf

--- a/src/ingestion/SimpleDataParser.hpp
+++ b/src/ingestion/SimpleDataParser.hpp
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <filesystem>
+#include <functional>
+
+#include "common/MarketDataEvent.hpp"
+
+namespace cmf {
+
+class SimpleDataParser {
+public:
+    explicit SimpleDataParser(std::filesystem::path path)
+        : path_(std::move(path)) {}
+
+    void parse_inner(const std::function<void(const MarketDataEvent&)>& f) const;
+
+private:
+    std::filesystem::path path_;
+};
+
+} // namespace cmf

--- a/src/main/CMakeLists.txt
+++ b/src/main/CMakeLists.txt
@@ -6,6 +6,7 @@ set(TARGET back-tester-lib)
 add_library(${TARGET} STATIC ${SRC})
 target_link_libraries(${TARGET} PUBLIC
     back-tester-common
+    back-tester-ingestion
 )
 
 # executable

--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -1,22 +1,83 @@
-// main function for the back-tester app
-// please, keep it minimalistic
-
-#include "common/BasicTypes.hpp"
-
+#include <chrono>
+#include <fstream>
 #include <iostream>
+#include <optional>
+#include <string>
+
+#include "common/LimitOrderBook.hpp"
+#include "common/MarketDataEvent.hpp"
+#include "common/PriceUtils.hpp"
+#include "ingestion/SimpleDataParser.hpp"
 
 using namespace cmf;
 
-int main([[maybe_unused]] int argc, [[maybe_unused]] const char *argv[])
-{
-    try
-    {
-        std::cout << "Hell! Oh, world!" << std::endl;
-    }
-    catch (std::exception &ex)
-    {
-        std::cerr << "Back-tester threw an exception: " << ex.what() << std::endl;
+int main(int argc, char* argv[]) {
+    if (argc < 2) {
+        std::cerr << "Usage: " << argv[0] << " <json_l3_file>\n";
         return 1;
+    }
+
+    const std::string path = argv[1];
+
+    LimitOrderBook book;
+    SimpleDataParser parser(path);
+
+    std::size_t totalEvents = 0;
+
+    std::optional<NanoTime>   prev_ts_event;
+    std::optional<std::uint32_t> prev_sequence;
+
+    auto t0 = std::chrono::steady_clock::now();
+
+    parser.parse_inner([&](const MarketDataEvent& ev) {
+        // chronological order check
+        if (prev_ts_event) {
+            if (ev.ts_event < *prev_ts_event ||
+               (ev.ts_event == *prev_ts_event && ev.sequence < *prev_sequence)) {
+                std::cerr << "Non-monotonic (ts_event, sequence) at event #"
+                          << totalEvents << "\n";
+            }
+        }
+        prev_ts_event = ev.ts_event;
+        prev_sequence = ev.sequence;
+
+        book.apply(ev);
+        ++totalEvents;
+
+        if (totalEvents == 1'000 ||
+            totalEvents == 100'000 ||
+            totalEvents == 500'000) {
+            std::cout << "\n--- Snapshot at event " << totalEvents << " ---\n";
+            book.printSnapshot(10);
+        }
+    });
+
+    auto t1 = std::chrono::steady_clock::now();
+    double seconds = std::chrono::duration<double>(t1 - t0).count();
+    double eps = seconds > 0.0 ? totalEvents / seconds : 0.0;
+
+    std::cout << "Total events: " << totalEvents << "\n";
+    std::cout << "Processing time: " << seconds << " s\n";
+    std::cout << "Events/sec: " << eps << "\n\n";
+
+    std::cout << "----- Final LOB Snapshot -----\n";
+    book.printSnapshot(10);
+
+    auto bestBid = book.bestBid();
+    auto bestAsk = book.bestAsk();
+
+    if (bestBid) {
+        std::cout << "Best bid: price=" << formatScaledPrice(bestBid->first)
+                  << " qty=" << bestBid->second << "\n";
+    } else {
+        std::cout << "Best bid: none\n";
+    }
+
+    if (bestAsk) {
+        std::cout << "Best ask: price=" << formatScaledPrice(bestAsk->first)
+                  << " qty=" << bestAsk->second << "\n";
+    } else {
+        std::cout << "Best ask: none\n";
     }
 
     return 0;


### PR DESCRIPTION
Implemented full LOB reconstruction for the standard variant: support for Add/Cancel/Modify/Trade/Fill, aggregated L2 book, best bid/ask queries, periodic and final snapshots, and performance stats for a single JSON L3 file processed sequentially.

Note: The JSON data parser is not implemented by me. I reused the implementation from @mrk-andreev.