### PR TITLE
feat(hw2): add multi-instrument LOB replay

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ build/bin/back-tester
 Smoke test against one real zipped Databento file:
 
 ```bash
-python3 scripts/smoke_ingest.py
+python3 scripts/smoke_ingest.py --zip /path/to/day.zip
 ```
 
 Hard-variant run against an extracted folder of daily JSON files:
@@ -95,10 +95,12 @@ Hard-variant run against an extracted folder of daily JSON files:
 build/bin/back-tester /path/to/folder --strategy both --preview-limit 10
 ```
 
-Benchmark all `.mbo.json` members inside the task zips and write reports:
+Benchmark all `.mbo.json` members inside one or more input zips and write reports:
 
 ```bash
 python3 scripts/bench_zip_ingest.py \
+  --zip /path/to/day-1.zip \
+  --zip /path/to/day-2.zip \
   --csv-out build/bench/ingest.csv \
   --md-out build/bench/ingest.md
 ```
@@ -114,9 +116,9 @@ python3 scripts/bench_folder_ingest.py \
 Useful bounded runs:
 
 ```bash
-python3 scripts/bench_zip_ingest.py --limit-members 1
-python3 scripts/bench_zip_ingest.py --member-substr 20260406
-python3 scripts/bench_folder_ingest.py --limit-files 4
+python3 scripts/bench_zip_ingest.py --task-inbox /path/to/zips --limit-members 1
+python3 scripts/bench_zip_ingest.py --task-inbox /path/to/zips --member-substr 20260406
+python3 scripts/bench_folder_ingest.py --task-inbox /path/to/zips --limit-files 4
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -83,6 +83,27 @@ Back-tester:
 build/bin/back-tester
 ```
 
+Smoke test against one real zipped Databento file:
+
+```bash
+python3 scripts/smoke_ingest.py
+```
+
+Benchmark all `.mbo.json` members inside the task zips and write reports:
+
+```bash
+python3 scripts/bench_zip_ingest.py \
+  --csv-out build/bench/ingest.csv \
+  --md-out build/bench/ingest.md
+```
+
+Useful bounded runs:
+
+```bash
+python3 scripts/bench_zip_ingest.py --limit-members 1
+python3 scripts/bench_zip_ingest.py --member-substr 20260406
+```
+
 ## Contributing
 
 Install UV, create a virtual environment, and install the project dependencies:

--- a/README.md
+++ b/README.md
@@ -89,6 +89,12 @@ Smoke test against one real zipped Databento file:
 python3 scripts/smoke_ingest.py
 ```
 
+Hard-variant run against an extracted folder of daily JSON files:
+
+```bash
+build/bin/back-tester /path/to/folder --strategy both --preview-limit 10
+```
+
 Benchmark all `.mbo.json` members inside the task zips and write reports:
 
 ```bash
@@ -97,11 +103,20 @@ python3 scripts/bench_zip_ingest.py \
   --md-out build/bench/ingest.md
 ```
 
+Benchmark hard-variant folder ingest for both merge strategies:
+
+```bash
+python3 scripts/bench_folder_ingest.py \
+  --csv-out build/bench/hard_ingest.csv \
+  --md-out build/bench/hard_ingest.md
+```
+
 Useful bounded runs:
 
 ```bash
 python3 scripts/bench_zip_ingest.py --limit-members 1
 python3 scripts/bench_zip_ingest.py --member-substr 20260406
+python3 scripts/bench_folder_ingest.py --limit-files 4
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -95,6 +95,26 @@ Hard-variant run against an extracted folder of daily JSON files:
 build/bin/back-tester /path/to/folder --strategy both --preview-limit 10
 ```
 
+Homework 2 style run with LOB snapshots and bounded final-book output:
+
+```bash
+build/bin/back-tester /path/to/folder \
+  --strategy both \
+  --preview-limit 0 \
+  --snapshot-every 500000 \
+  --snapshot-depth 5 \
+  --max-snapshots 3 \
+  --final-books-limit 20
+```
+
+Convert raw Databento NDJSON files into Feather:
+
+```bash
+uv run --no-project scripts/convert_to_feather.py \
+  /path/to/xeur-eobi-20260310.mbo.json \
+  --out-dir build/feather
+```
+
 Benchmark all `.mbo.json` members inside one or more input zips and write reports:
 
 ```bash

--- a/cmake/GlobalSettings.cmake
+++ b/cmake/GlobalSettings.cmake
@@ -57,5 +57,19 @@ add_compile_options($<$<CONFIG:Release>:-O3> $<$<CONFIG:Release>:-DNDEBUG>)
 add_compile_options(-Werror -Wall -Wextra)
 #add_compile_options(-Wfatal-errors -ftemplate-backtrace-limit=0)
 
+# Some Command Line Tools installs ship libc++ headers only inside the SDK.
+# Inject that path when the compiler's default libc++ include dir is empty so
+# both this project and ExternalProject dependencies can still build.
+if(APPLE AND CMAKE_OSX_SYSROOT)
+    get_filename_component(CXX_BIN_DIR "${CMAKE_CXX_COMPILER}" DIRECTORY)
+    set(CXX_TOOLCHAIN_LIBCXX_DIR "${CXX_BIN_DIR}/../include/c++/v1")
+    set(CXX_SDK_LIBCXX_DIR "${CMAKE_OSX_SYSROOT}/usr/include/c++/v1")
+    if(EXISTS "${CXX_SDK_LIBCXX_DIR}/cassert" AND
+       NOT EXISTS "${CXX_TOOLCHAIN_LIBCXX_DIR}/cassert")
+        string(APPEND CMAKE_CXX_FLAGS " -isystem ${CXX_SDK_LIBCXX_DIR}")
+        print_message("libc++ fallback:    ${CXX_SDK_LIBCXX_DIR}")
+    endif()
+endif()
+
 # Include dir
 include_directories(src)

--- a/cmake/ThirdPartyLibs.cmake
+++ b/cmake/ThirdPartyLibs.cmake
@@ -14,6 +14,11 @@ set(FORWARDED_CMAKE_ARGS
 
 set(DESTDIR "")
 
+file(MAKE_DIRECTORY
+    "${CMAKE_BINARY_DIR}/include"
+    "${CMAKE_BINARY_DIR}/lib"
+)
+
 function(add_external_install_paths TARGET_NAME)
     target_include_directories(${TARGET_NAME} SYSTEM PUBLIC INTERFACE
         "${CMAKE_BINARY_DIR}/include"
@@ -21,11 +26,6 @@ function(add_external_install_paths TARGET_NAME)
     target_link_directories(${TARGET_NAME} PUBLIC INTERFACE
         "${CMAKE_BINARY_DIR}/lib"
     )
-    if(EXISTS "${CMAKE_BINARY_DIR}/lib64")
-        target_link_directories(${TARGET_NAME} PUBLIC INTERFACE
-            "${CMAKE_BINARY_DIR}/lib64"
-        )
-    endif()
 endfunction()
 
 function(configure_git_or_local_external)

--- a/cmake/ThirdPartyLibs.cmake
+++ b/cmake/ThirdPartyLibs.cmake
@@ -14,6 +14,24 @@ set(FORWARDED_CMAKE_ARGS
 
 set(DESTDIR "")
 
+function(add_external_install_paths TARGET_NAME)
+    if(EXISTS "${CMAKE_BINARY_DIR}/include")
+        target_include_directories(${TARGET_NAME} SYSTEM PUBLIC INTERFACE
+            "${CMAKE_BINARY_DIR}/include"
+        )
+    endif()
+    if(EXISTS "${CMAKE_BINARY_DIR}/lib")
+        target_link_directories(${TARGET_NAME} PUBLIC INTERFACE
+            "${CMAKE_BINARY_DIR}/lib"
+        )
+    endif()
+    if(EXISTS "${CMAKE_BINARY_DIR}/lib64")
+        target_link_directories(${TARGET_NAME} PUBLIC INTERFACE
+            "${CMAKE_BINARY_DIR}/lib64"
+        )
+    endif()
+endfunction()
+
 # ---------------------------------------------------------------------------------------
 # Catch2 - C++ testing framework
 ExternalProject_Add(
@@ -32,10 +50,32 @@ ExternalProject_Add(
 set(TGT Catch2-static-lib)
 add_library(${TGT} INTERFACE)
 add_dependencies(${TGT} Catch2)
-target_include_directories(${TGT} SYSTEM PUBLIC INTERFACE ${CMAKE_BINARY_DIR}/include)
-target_link_directories(${TGT} PUBLIC INTERFACE ${CMAKE_BINARY_DIR}/lib ${CMAKE_BINARY_DIR}/lib64)
+add_external_install_paths(${TGT})
 target_link_libraries(${TGT} PUBLIC INTERFACE
     $<$<CONFIG:Debug>:-lCatch2Maind -lCatch2d>
     $<$<CONFIG:Release>:-lCatch2Main -lCatch2>
 )
 
+# ---------------------------------------------------------------------------------------
+# simdjson - fast JSON parser, used by the ingest layer
+ExternalProject_Add(
+    simdjson
+    GIT_REPOSITORY https://github.com/simdjson/simdjson.git
+    GIT_TAG v3.10.1
+    GIT_SHALLOW TRUE
+    GIT_PROGRESS TRUE
+    SOURCE_DIR "${CMAKE_SOURCE_DIR}/3rdparty/simdjson"
+    BINARY_DIR "${CMAKE_BINARY_DIR}/3rdparty/simdjson"
+    CMAKE_ARGS ${FORWARDED_CMAKE_ARGS}
+        -DSIMDJSON_DEVELOPER_MODE=OFF
+        -DSIMDJSON_JUST_LIBRARY=ON
+        -DBUILD_SHARED_LIBS=OFF
+    BUILD_COMMAND $(MAKE)
+    INSTALL_COMMAND $(MAKE) -s DESTDIR=${DESTDIR} install
+)
+
+set(TGT simdjson-static-lib)
+add_library(${TGT} INTERFACE)
+add_dependencies(${TGT} simdjson)
+add_external_install_paths(${TGT})
+target_link_libraries(${TGT} PUBLIC INTERFACE -lsimdjson)

--- a/cmake/ThirdPartyLibs.cmake
+++ b/cmake/ThirdPartyLibs.cmake
@@ -15,16 +15,12 @@ set(FORWARDED_CMAKE_ARGS
 set(DESTDIR "")
 
 function(add_external_install_paths TARGET_NAME)
-    if(EXISTS "${CMAKE_BINARY_DIR}/include")
-        target_include_directories(${TARGET_NAME} SYSTEM PUBLIC INTERFACE
-            "${CMAKE_BINARY_DIR}/include"
-        )
-    endif()
-    if(EXISTS "${CMAKE_BINARY_DIR}/lib")
-        target_link_directories(${TARGET_NAME} PUBLIC INTERFACE
-            "${CMAKE_BINARY_DIR}/lib"
-        )
-    endif()
+    target_include_directories(${TARGET_NAME} SYSTEM PUBLIC INTERFACE
+        "${CMAKE_BINARY_DIR}/include"
+    )
+    target_link_directories(${TARGET_NAME} PUBLIC INTERFACE
+        "${CMAKE_BINARY_DIR}/lib"
+    )
     if(EXISTS "${CMAKE_BINARY_DIR}/lib64")
         target_link_directories(${TARGET_NAME} PUBLIC INTERFACE
             "${CMAKE_BINARY_DIR}/lib64"
@@ -32,19 +28,48 @@ function(add_external_install_paths TARGET_NAME)
     endif()
 endfunction()
 
+function(configure_git_or_local_external)
+    set(options)
+    set(oneValueArgs TARGET_NAME SOURCE_DIR BINARY_DIR GIT_REPOSITORY GIT_TAG)
+    set(multiValueArgs CMAKE_ARGS)
+    cmake_parse_arguments(EXT "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+    if(EXISTS "${EXT_SOURCE_DIR}/CMakeLists.txt")
+        ExternalProject_Add(
+            ${EXT_TARGET_NAME}
+            SOURCE_DIR "${EXT_SOURCE_DIR}"
+            BINARY_DIR "${EXT_BINARY_DIR}"
+            DOWNLOAD_COMMAND ""
+            UPDATE_COMMAND ""
+            CMAKE_ARGS ${EXT_CMAKE_ARGS}
+            BUILD_COMMAND $(MAKE)
+            INSTALL_COMMAND $(MAKE) -s DESTDIR=${DESTDIR} install
+        )
+    else()
+        ExternalProject_Add(
+            ${EXT_TARGET_NAME}
+            GIT_REPOSITORY ${EXT_GIT_REPOSITORY}
+            GIT_TAG ${EXT_GIT_TAG}
+            GIT_SHALLOW TRUE
+            GIT_PROGRESS TRUE
+            SOURCE_DIR "${EXT_SOURCE_DIR}"
+            BINARY_DIR "${EXT_BINARY_DIR}"
+            CMAKE_ARGS ${EXT_CMAKE_ARGS}
+            BUILD_COMMAND $(MAKE)
+            INSTALL_COMMAND $(MAKE) -s DESTDIR=${DESTDIR} install
+        )
+    endif()
+endfunction()
+
 # ---------------------------------------------------------------------------------------
 # Catch2 - C++ testing framework
-ExternalProject_Add(
-    Catch2
+configure_git_or_local_external(
+    TARGET_NAME Catch2
     GIT_REPOSITORY https://github.com/catchorg/Catch2.git
     GIT_TAG v3.8.1
-    GIT_SHALLOW TRUE
-    GIT_PROGRESS TRUE
     SOURCE_DIR "${CMAKE_SOURCE_DIR}/3rdparty/Catch2"
     BINARY_DIR "${CMAKE_BINARY_DIR}/3rdparty/Catch2"
     CMAKE_ARGS ${FORWARDED_CMAKE_ARGS}
-    BUILD_COMMAND $(MAKE)
-    INSTALL_COMMAND $(MAKE) -s DESTDIR=${DESTDIR} install
 )
 
 set(TGT Catch2-static-lib)
@@ -58,20 +83,16 @@ target_link_libraries(${TGT} PUBLIC INTERFACE
 
 # ---------------------------------------------------------------------------------------
 # simdjson - fast JSON parser, used by the ingest layer
-ExternalProject_Add(
-    simdjson
+configure_git_or_local_external(
+    TARGET_NAME simdjson
     GIT_REPOSITORY https://github.com/simdjson/simdjson.git
     GIT_TAG v3.10.1
-    GIT_SHALLOW TRUE
-    GIT_PROGRESS TRUE
     SOURCE_DIR "${CMAKE_SOURCE_DIR}/3rdparty/simdjson"
     BINARY_DIR "${CMAKE_BINARY_DIR}/3rdparty/simdjson"
     CMAKE_ARGS ${FORWARDED_CMAKE_ARGS}
         -DSIMDJSON_DEVELOPER_MODE=OFF
         -DSIMDJSON_JUST_LIBRARY=ON
         -DBUILD_SHARED_LIBS=OFF
-    BUILD_COMMAND $(MAKE)
-    INSTALL_COMMAND $(MAKE) -s DESTDIR=${DESTDIR} install
 )
 
 set(TGT simdjson-static-lib)

--- a/scripts/bench_folder_ingest.py
+++ b/scripts/bench_folder_ingest.py
@@ -13,6 +13,14 @@ from dataclasses import dataclass
 from pathlib import Path
 
 
+def find_default_inbox(repo_root: Path) -> Path | None:
+    for base in (repo_root, *repo_root.parents):
+        candidate = base / ".axxeny-code" / "tasks" / "001-hw1" / "inbox"
+        if candidate.exists():
+            return candidate
+    return None
+
+
 @dataclass
 class BenchRow:
     strategy: str
@@ -29,7 +37,7 @@ class BenchRow:
 def parse_args() -> argparse.Namespace:
     repo_root = Path(__file__).resolve().parents[1]
     default_binary = repo_root / "build" / "bin" / "back-tester"
-    default_inbox = repo_root.parents[1] / "tasks" / "001-hw1" / "inbox"
+    default_inbox = find_default_inbox(repo_root)
 
     parser = argparse.ArgumentParser(
         description=(
@@ -51,13 +59,19 @@ def parse_args() -> argparse.Namespace:
         action="append",
         type=Path,
         default=[],
-        help="Zip file to use. Repeatable. Default: all zips in task inbox.",
+        help=(
+            "Zip file to use. Repeatable. Default: all zips in the auto-detected "
+            "task inbox when available."
+        ),
     )
     parser.add_argument(
         "--task-inbox",
         type=Path,
         default=default_inbox,
-        help="Task inbox holding zip files.",
+        help=(
+            "Directory holding input zip files. Default: auto-detect the repo-local "
+            "task inbox when available."
+        ),
     )
     parser.add_argument(
         "--member-substr",
@@ -85,9 +99,13 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def pick_zip_paths(task_inbox: Path, explicit: list[Path]) -> list[Path]:
+def pick_zip_paths(task_inbox: Path | None, explicit: list[Path]) -> list[Path]:
     if explicit:
         return explicit
+    if task_inbox is None:
+        raise FileNotFoundError(
+            "No default zip location found. Pass --zip or --task-inbox."
+        )
     paths = sorted(task_inbox.glob("*.zip"))
     if not paths:
         raise FileNotFoundError(f"No zip files found in {task_inbox}")

--- a/scripts/bench_folder_ingest.py
+++ b/scripts/bench_folder_ingest.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import csv
+import shutil
+import subprocess
+import sys
+import tempfile
+import zipfile
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass
+class BenchRow:
+    strategy: str
+    files: int
+    messages: int
+    elapsed_sec: float
+    msgs_per_sec: float
+    skipped_rtype: int
+    skipped_parse: int
+    out_of_order_ts_recv: int
+    exit_code: int
+
+
+def parse_args() -> argparse.Namespace:
+    repo_root = Path(__file__).resolve().parents[1]
+    default_binary = repo_root / "build" / "bin" / "back-tester"
+    default_inbox = repo_root.parents[1] / "tasks" / "001-hw1" / "inbox"
+
+    parser = argparse.ArgumentParser(
+        description=(
+            "Benchmark hard-variant folder ingest. By default extracts all "
+            ".mbo.json members from task zip files into a temp folder, then "
+            "runs both merge strategies."
+        )
+    )
+    parser.add_argument("--binary", type=Path, default=default_binary)
+    parser.add_argument(
+        "--input-dir",
+        type=Path,
+        default=None,
+        help="Pre-extracted folder of .json/.ndjson files. Skips zip extraction.",
+    )
+    parser.add_argument(
+        "--zip",
+        dest="zip_paths",
+        action="append",
+        type=Path,
+        default=[],
+        help="Zip file to use. Repeatable. Default: all zips in task inbox.",
+    )
+    parser.add_argument(
+        "--task-inbox",
+        type=Path,
+        default=default_inbox,
+        help="Task inbox holding zip files.",
+    )
+    parser.add_argument(
+        "--member-substr",
+        type=str,
+        default=None,
+        help="Only extract members whose path contains this substring.",
+    )
+    parser.add_argument(
+        "--limit-files",
+        type=int,
+        default=None,
+        help="Only extract first N matching members after sorting.",
+    )
+    parser.add_argument(
+        "--scratch-dir",
+        type=Path,
+        default=None,
+        help=(
+            "Directory under which temporary extracted files should live. "
+            "Useful when the default system temp volume is too small."
+        ),
+    )
+    parser.add_argument("--csv-out", type=Path, default=None)
+    parser.add_argument("--md-out", type=Path, default=None)
+    return parser.parse_args()
+
+
+def pick_zip_paths(task_inbox: Path, explicit: list[Path]) -> list[Path]:
+    if explicit:
+        return explicit
+    paths = sorted(task_inbox.glob("*.zip"))
+    if not paths:
+        raise FileNotFoundError(f"No zip files found in {task_inbox}")
+    return paths
+
+
+def extract_members(args: argparse.Namespace, dst: Path) -> int:
+    extracted = 0
+    members: list[tuple[Path, zipfile.ZipInfo]] = []
+    for zip_path in pick_zip_paths(args.task_inbox, args.zip_paths):
+        with zipfile.ZipFile(zip_path) as zf:
+            for info in zf.infolist():
+                if info.is_dir() or not info.filename.endswith(".mbo.json"):
+                    continue
+                if args.member_substr and args.member_substr not in info.filename:
+                    continue
+                members.append((zip_path, info))
+
+    members.sort(key=lambda item: (item[0].name, item[1].filename))
+    if args.limit_files is not None:
+        members = members[: args.limit_files]
+    if not members:
+        raise FileNotFoundError("No matching .mbo.json members found.")
+
+    for index, (zip_path, info) in enumerate(members):
+        dst_name = f"{index:03d}_{Path(info.filename).name}"
+        out_path = dst / dst_name
+        with zipfile.ZipFile(zip_path) as zf:
+            with zf.open(info.filename) as src, out_path.open("wb") as out:
+                shutil.copyfileobj(src, out)
+        extracted += 1
+    return extracted
+
+
+def parse_summary(stdout: str) -> dict[str, str]:
+    lines = [line.strip() for line in stdout.splitlines() if line.strip()]
+    summary_line = next(
+        (line for line in reversed(lines) if line.startswith("strategy=")),
+        None,
+    )
+    if summary_line is None:
+        raise ValueError("Could not find strategy summary line in binary output")
+
+    result: dict[str, str] = {}
+    for token in summary_line.split():
+        key, value = token.split("=", 1)
+        result[key] = value
+    return result
+
+
+def bench_strategy(binary: Path, input_dir: Path, strategy: str) -> BenchRow:
+    result = subprocess.run(
+        [
+            str(binary),
+            str(input_dir),
+            "--strategy",
+            strategy,
+            "--preview-limit",
+            "0",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    if result.returncode != 0:
+        return BenchRow(strategy, 0, 0, 0.0, 0.0, 0, 0, 0, result.returncode)
+
+    summary = parse_summary(result.stdout)
+    return BenchRow(
+        strategy=summary["strategy"],
+        files=int(summary["files"]),
+        messages=int(summary["total"]),
+        elapsed_sec=float(summary["elapsed_sec"]),
+        msgs_per_sec=float(summary["msgs_per_sec"]),
+        skipped_rtype=int(summary["skipped_rtype"]),
+        skipped_parse=int(summary["skipped_parse"]),
+        out_of_order_ts_recv=int(summary["out_of_order_ts_recv"]),
+        exit_code=result.returncode,
+    )
+
+
+def write_csv(path: Path, rows: list[BenchRow]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", newline="") as fh:
+        writer = csv.writer(fh)
+        writer.writerow(BenchRow.__annotations__.keys())
+        for row in rows:
+            writer.writerow(
+                [
+                    row.strategy,
+                    row.files,
+                    row.messages,
+                    f"{row.elapsed_sec:.6f}",
+                    f"{row.msgs_per_sec:.2f}",
+                    row.skipped_rtype,
+                    row.skipped_parse,
+                    row.out_of_order_ts_recv,
+                    row.exit_code,
+                ]
+            )
+
+
+def write_markdown(path: Path, rows: list[BenchRow], input_dir: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w") as fh:
+        fh.write("# Hard Ingest Bench\n\n")
+        fh.write(f"- input_dir: `{input_dir}`\n")
+        fh.write(f"- strategies: {', '.join(row.strategy for row in rows)}\n\n")
+        fh.write(
+            "| strategy | files | messages | elapsed_sec | msgs_per_sec | skipped_rtype | skipped_parse | out_of_order | exit |\n"
+        )
+        fh.write("|---|---:|---:|---:|---:|---:|---:|---:|---:|\n")
+        for row in rows:
+            fh.write(
+                f"| `{row.strategy}` | {row.files} | {row.messages} | "
+                f"{row.elapsed_sec:.6f} | {row.msgs_per_sec:.2f} | "
+                f"{row.skipped_rtype} | {row.skipped_parse} | "
+                f"{row.out_of_order_ts_recv} | {row.exit_code} |\n"
+            )
+
+
+def main() -> int:
+    args = parse_args()
+    if not args.binary.exists():
+        raise FileNotFoundError(
+            f"Binary not found: {args.binary}. Build first with `cmake -S . -B build && cmake --build build`."
+        )
+
+    scratch_dir = args.scratch_dir
+    if scratch_dir is not None:
+        scratch_dir.mkdir(parents=True, exist_ok=True)
+
+    with tempfile.TemporaryDirectory(
+        prefix="back-tester-hard-bench-",
+        dir=str(scratch_dir) if scratch_dir is not None else None,
+    ) as tmp_name:
+        extracted_dir = Path(tmp_name)
+        input_dir = args.input_dir
+        if input_dir is None:
+            extract_count = extract_members(args, extracted_dir)
+            input_dir = extracted_dir
+            print(f"extracted_files={extract_count}")
+
+        rows = [
+            bench_strategy(args.binary, input_dir, "flat"),
+            bench_strategy(args.binary, input_dir, "hierarchy"),
+        ]
+
+        for row in rows:
+            print(
+                f"strategy={row.strategy},files={row.files},messages={row.messages},"
+                f"elapsed_sec={row.elapsed_sec:.6f},msgs_per_sec={row.msgs_per_sec:.2f},"
+                f"exit={row.exit_code}"
+            )
+
+        if any(row.exit_code != 0 for row in rows):
+            return 1
+
+        if args.csv_out is not None:
+            write_csv(args.csv_out, rows)
+            print(f"csv_out={args.csv_out}")
+        if args.md_out is not None:
+            write_markdown(args.md_out, rows, input_dir)
+            print(f"md_out={args.md_out}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/bench_zip_ingest.py
+++ b/scripts/bench_zip_ingest.py
@@ -1,0 +1,256 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import csv
+import subprocess
+import sys
+import tempfile
+import time
+import zipfile
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass
+class BenchRow:
+    zip_path: str
+    member: str
+    bytes_uncompressed: int
+    messages: int
+    elapsed_sec: float
+    msgs_per_sec: float
+    skipped_rtype: int
+    skipped_parse: int
+    out_of_order_ts_recv: int
+    exit_code: int
+
+
+def parse_args() -> argparse.Namespace:
+    repo_root = Path(__file__).resolve().parents[1]
+    default_binary = repo_root / "build" / "bin" / "back-tester"
+    default_inbox = repo_root.parents[1] / "tasks" / "001-hw1" / "inbox"
+
+    parser = argparse.ArgumentParser(
+        description=(
+            "Benchmark back-tester over all .mbo.json members found inside one or "
+            "more task zip files. Extracts one member at a time to temp storage."
+        )
+    )
+    parser.add_argument(
+        "--binary",
+        type=Path,
+        default=default_binary,
+        help="Path to back-tester binary.",
+    )
+    parser.add_argument(
+        "--zip",
+        dest="zip_paths",
+        action="append",
+        type=Path,
+        default=[],
+        help="Zip file to benchmark. Repeatable. Default: all zips in task inbox.",
+    )
+    parser.add_argument(
+        "--task-inbox",
+        type=Path,
+        default=default_inbox,
+        help="Task inbox holding zip files.",
+    )
+    parser.add_argument(
+        "--limit-members",
+        type=int,
+        default=None,
+        help="Only bench first N .mbo.json members per zip.",
+    )
+    parser.add_argument(
+        "--member-substr",
+        type=str,
+        default=None,
+        help="Only bench members whose path contains this substring.",
+    )
+    parser.add_argument(
+        "--csv-out",
+        type=Path,
+        default=None,
+        help="Optional CSV output path.",
+    )
+    parser.add_argument(
+        "--md-out",
+        type=Path,
+        default=None,
+        help="Optional Markdown report output path.",
+    )
+    return parser.parse_args()
+
+
+def pick_zip_paths(task_inbox: Path, explicit: list[Path]) -> list[Path]:
+    if explicit:
+        return explicit
+    paths = sorted(task_inbox.glob("*.zip"))
+    if not paths:
+        raise FileNotFoundError(f"No zip files found in {task_inbox}")
+    return paths
+
+
+def parse_summary(stdout: str) -> dict[str, int]:
+    lines = [line.strip() for line in stdout.splitlines() if line.strip()]
+    summary_line = next(
+        (line for line in reversed(lines) if line.startswith("total=")),
+        None,
+    )
+    if summary_line is None:
+        raise ValueError("Could not find summary line in binary output")
+
+    result: dict[str, int] = {}
+    for token in summary_line.split():
+        key, value = token.split("=", 1)
+        result[key] = int(value)
+    return result
+
+
+def bench_member(binary: Path, zip_path: Path, info: zipfile.ZipInfo) -> BenchRow:
+    with tempfile.TemporaryDirectory(prefix="back-tester-bench-") as tmp_dir_name:
+        tmp_dir = Path(tmp_dir_name)
+        extracted = tmp_dir / Path(info.filename).name
+
+        with zipfile.ZipFile(zip_path) as zf:
+            with zf.open(info.filename) as src, extracted.open("wb") as dst:
+                dst.write(src.read())
+
+        start = time.perf_counter()
+        result = subprocess.run(
+            [str(binary), str(extracted)],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        elapsed = time.perf_counter() - start
+
+    messages = 0
+    skipped_rtype = 0
+    skipped_parse = 0
+    out_of_order = 0
+    if result.returncode == 0:
+        summary = parse_summary(result.stdout)
+        messages = summary["total"]
+        skipped_rtype = summary["skipped_rtype"]
+        skipped_parse = summary["skipped_parse"]
+        out_of_order = summary["out_of_order_ts_recv"]
+
+    msgs_per_sec = messages / elapsed if elapsed > 0 else 0.0
+    return BenchRow(
+        zip_path=str(zip_path),
+        member=info.filename,
+        bytes_uncompressed=info.file_size,
+        messages=messages,
+        elapsed_sec=elapsed,
+        msgs_per_sec=msgs_per_sec,
+        skipped_rtype=skipped_rtype,
+        skipped_parse=skipped_parse,
+        out_of_order_ts_recv=out_of_order,
+        exit_code=result.returncode,
+    )
+
+
+def write_csv(path: Path, rows: list[BenchRow]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", newline="") as fh:
+        writer = csv.writer(fh)
+        writer.writerow(BenchRow.__annotations__.keys())
+        for row in rows:
+            writer.writerow(
+                [
+                    row.zip_path,
+                    row.member,
+                    row.bytes_uncompressed,
+                    row.messages,
+                    f"{row.elapsed_sec:.6f}",
+                    f"{row.msgs_per_sec:.2f}",
+                    row.skipped_rtype,
+                    row.skipped_parse,
+                    row.out_of_order_ts_recv,
+                    row.exit_code,
+                ]
+            )
+
+
+def write_markdown(path: Path, rows: list[BenchRow]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    total_messages = sum(row.messages for row in rows)
+    total_elapsed = sum(row.elapsed_sec for row in rows)
+    total_rate = total_messages / total_elapsed if total_elapsed > 0 else 0.0
+
+    with path.open("w") as fh:
+        fh.write("# Ingest Bench\n\n")
+        fh.write(
+            f"- files: {len(rows)}\n"
+            f"- messages: {total_messages}\n"
+            f"- elapsed_sec: {total_elapsed:.6f}\n"
+            f"- msgs_per_sec: {total_rate:.2f}\n\n"
+        )
+        fh.write(
+            "| zip | member | bytes | messages | elapsed_sec | msgs_per_sec | exit |\n"
+        )
+        fh.write("|---|---|---:|---:|---:|---:|---:|\n")
+        for row in rows:
+            fh.write(
+                f"| `{Path(row.zip_path).name}` | `{Path(row.member).name}` | "
+                f"{row.bytes_uncompressed} | {row.messages} | {row.elapsed_sec:.6f} | "
+                f"{row.msgs_per_sec:.2f} | {row.exit_code} |\n"
+            )
+
+
+def main() -> int:
+    args = parse_args()
+    if not args.binary.exists():
+        raise FileNotFoundError(
+            f"Binary not found: {args.binary}. Build first with `cmake -S . -B build && cmake --build build`."
+        )
+
+    rows: list[BenchRow] = []
+    for zip_path in pick_zip_paths(args.task_inbox, args.zip_paths):
+        with zipfile.ZipFile(zip_path) as zf:
+            members = [
+                info
+                for info in zf.infolist()
+                if info.filename.endswith(".mbo.json") and not info.is_dir()
+            ]
+        if args.member_substr is not None:
+            members = [info for info in members if args.member_substr in info.filename]
+        if args.limit_members is not None:
+            members = members[: args.limit_members]
+
+        for info in members:
+            row = bench_member(args.binary, zip_path, info)
+            rows.append(row)
+            print(
+                f"{Path(zip_path).name},{Path(info.filename).name},"
+                f"messages={row.messages},elapsed_sec={row.elapsed_sec:.6f},"
+                f"msgs_per_sec={row.msgs_per_sec:.2f},exit={row.exit_code}"
+            )
+
+    if not rows:
+        print("No matching .mbo.json members found.", file=sys.stderr)
+        return 2
+
+    total_messages = sum(row.messages for row in rows)
+    total_elapsed = sum(row.elapsed_sec for row in rows)
+    total_rate = total_messages / total_elapsed if total_elapsed > 0 else 0.0
+    print(
+        f"TOTAL files={len(rows)} messages={total_messages} "
+        f"elapsed_sec={total_elapsed:.6f} msgs_per_sec={total_rate:.2f}"
+    )
+
+    if args.csv_out is not None:
+        write_csv(args.csv_out, rows)
+        print(f"csv_out={args.csv_out}")
+    if args.md_out is not None:
+        write_markdown(args.md_out, rows)
+        print(f"md_out={args.md_out}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/bench_zip_ingest.py
+++ b/scripts/bench_zip_ingest.py
@@ -13,6 +13,14 @@ from dataclasses import dataclass
 from pathlib import Path
 
 
+def find_default_inbox(repo_root: Path) -> Path | None:
+    for base in (repo_root, *repo_root.parents):
+        candidate = base / ".axxeny-code" / "tasks" / "001-hw1" / "inbox"
+        if candidate.exists():
+            return candidate
+    return None
+
+
 @dataclass
 class BenchRow:
     zip_path: str
@@ -30,7 +38,7 @@ class BenchRow:
 def parse_args() -> argparse.Namespace:
     repo_root = Path(__file__).resolve().parents[1]
     default_binary = repo_root / "build" / "bin" / "back-tester"
-    default_inbox = repo_root.parents[1] / "tasks" / "001-hw1" / "inbox"
+    default_inbox = find_default_inbox(repo_root)
 
     parser = argparse.ArgumentParser(
         description=(
@@ -50,13 +58,19 @@ def parse_args() -> argparse.Namespace:
         action="append",
         type=Path,
         default=[],
-        help="Zip file to benchmark. Repeatable. Default: all zips in task inbox.",
+        help=(
+            "Zip file to benchmark. Repeatable. Default: all zips in the "
+            "auto-detected task inbox when available."
+        ),
     )
     parser.add_argument(
         "--task-inbox",
         type=Path,
         default=default_inbox,
-        help="Task inbox holding zip files.",
+        help=(
+            "Directory holding input zip files. Default: auto-detect the repo-local "
+            "task inbox when available."
+        ),
     )
     parser.add_argument(
         "--limit-members",
@@ -85,9 +99,13 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def pick_zip_paths(task_inbox: Path, explicit: list[Path]) -> list[Path]:
+def pick_zip_paths(task_inbox: Path | None, explicit: list[Path]) -> list[Path]:
     if explicit:
         return explicit
+    if task_inbox is None:
+        raise FileNotFoundError(
+            "No default zip location found. Pass --zip or --task-inbox."
+        )
     paths = sorted(task_inbox.glob("*.zip"))
     if not paths:
         raise FileNotFoundError(f"No zip files found in {task_inbox}")

--- a/scripts/convert_to_feather.py
+++ b/scripts/convert_to_feather.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#   "pyarrow>=16.1.0",
+# ]
+# ///
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import pyarrow as pa
+import pyarrow.feather as feather
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Convert Databento NDJSON MBO files into Feather tables."
+    )
+    parser.add_argument("inputs", nargs="+", help="Input .json/.mbo.json files")
+    parser.add_argument(
+        "--out-dir",
+        type=Path,
+        default=None,
+        help="Output directory for .feather files (default: beside each input)",
+    )
+    parser.add_argument(
+        "--compression",
+        default="lz4",
+        choices=("lz4", "zstd", "uncompressed"),
+        help="Feather compression codec",
+    )
+    return parser.parse_args()
+
+
+def normalise_record(record: dict) -> dict:
+    header = record.get("hd", {})
+    return {
+        "ts_recv": record.get("ts_recv"),
+        "ts_event": header.get("ts_event", record.get("ts_event")),
+        "rtype": header.get("rtype", record.get("rtype")),
+        "publisher_id": header.get("publisher_id", record.get("publisher_id")),
+        "instrument_id": header.get("instrument_id", record.get("instrument_id")),
+        "order_id": record.get("order_id"),
+        "action": record.get("action"),
+        "side": record.get("side"),
+        "price": record.get("price"),
+        "size": record.get("size"),
+        "channel_id": record.get("channel_id"),
+        "flags": record.get("flags"),
+        "ts_in_delta": record.get("ts_in_delta"),
+        "sequence": record.get("sequence"),
+        "symbol": record.get("symbol"),
+    }
+
+
+def convert_file(input_path: Path, output_path: Path, compression: str) -> int:
+    rows: list[dict] = []
+    with input_path.open("r", encoding="utf-8") as handle:
+        for line_no, line in enumerate(handle, start=1):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                record = json.loads(line)
+            except json.JSONDecodeError as exc:
+                raise ValueError(f"{input_path}:{line_no}: invalid JSON: {exc}") from exc
+            rows.append(normalise_record(record))
+
+    table = pa.Table.from_pylist(rows)
+    feather.write_feather(
+        table,
+        output_path,
+        compression=None if compression == "uncompressed" else compression,
+    )
+    return table.num_rows
+
+
+def main() -> int:
+    args = parse_args()
+    total_rows = 0
+
+    for raw_input in args.inputs:
+        input_path = Path(raw_input)
+        if not input_path.is_file():
+            raise FileNotFoundError(f"Input file not found: {input_path}")
+
+        output_dir = args.out_dir if args.out_dir is not None else input_path.parent
+        output_dir.mkdir(parents=True, exist_ok=True)
+        output_path = output_dir / f"{input_path.stem}.feather"
+
+        rows = convert_file(input_path, output_path, args.compression)
+        total_rows += rows
+        print(f"{input_path} -> {output_path} rows={rows}")
+
+    print(f"total_rows={total_rows}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/smoke_ingest.py
+++ b/scripts/smoke_ingest.py
@@ -10,10 +10,18 @@ import zipfile
 from pathlib import Path
 
 
+def find_default_inbox(repo_root: Path) -> Path | None:
+    for base in (repo_root, *repo_root.parents):
+        candidate = base / ".axxeny-code" / "tasks" / "001-hw1" / "inbox"
+        if candidate.exists():
+            return candidate
+    return None
+
+
 def parse_args() -> argparse.Namespace:
     repo_root = Path(__file__).resolve().parents[1]
     default_binary = repo_root / "build" / "bin" / "back-tester"
-    default_inbox = repo_root.parents[1] / "tasks" / "001-hw1" / "inbox"
+    default_inbox = find_default_inbox(repo_root)
 
     parser = argparse.ArgumentParser(
         description=(
@@ -51,12 +59,19 @@ def parse_args() -> argparse.Namespace:
         "--task-inbox",
         type=Path,
         default=default_inbox,
-        help="Task inbox holding zip files.",
+        help=(
+            "Directory holding input zip files. Default: auto-detect the repo-local "
+            "task inbox when available."
+        ),
     )
     return parser.parse_args()
 
 
-def pick_zip(task_inbox: Path) -> Path:
+def pick_zip(task_inbox: Path | None) -> Path:
+    if task_inbox is None:
+        raise FileNotFoundError(
+            "No default zip location found. Pass --zip or --task-inbox."
+        )
     candidates = sorted(task_inbox.glob("*.zip"))
     if not candidates:
         raise FileNotFoundError(f"No zip files found in {task_inbox}")

--- a/scripts/smoke_ingest.py
+++ b/scripts/smoke_ingest.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+import tempfile
+import zipfile
+from pathlib import Path
+
+
+def parse_args() -> argparse.Namespace:
+    repo_root = Path(__file__).resolve().parents[1]
+    default_binary = repo_root / "build" / "bin" / "back-tester"
+    default_inbox = repo_root.parents[1] / "tasks" / "001-hw1" / "inbox"
+
+    parser = argparse.ArgumentParser(
+        description=(
+            "Run a bounded smoke test of the ingest binary against one real "
+            "Databento JSON member stored inside a task zip."
+        )
+    )
+    parser.add_argument(
+        "--binary",
+        type=Path,
+        default=default_binary,
+        help="Path to back-tester binary.",
+    )
+    parser.add_argument(
+        "--zip",
+        dest="zip_path",
+        type=Path,
+        default=None,
+        help="Specific zip file to use. Default: smallest zip in task inbox.",
+    )
+    parser.add_argument(
+        "--member",
+        type=str,
+        default=None,
+        help=(
+            "Specific .mbo.json member inside zip. Default: smallest .mbo.json member."
+        ),
+    )
+    parser.add_argument(
+        "--keep-json",
+        action="store_true",
+        help="Keep extracted JSON file instead of deleting temp dir.",
+    )
+    parser.add_argument(
+        "--task-inbox",
+        type=Path,
+        default=default_inbox,
+        help="Task inbox holding zip files.",
+    )
+    return parser.parse_args()
+
+
+def pick_zip(task_inbox: Path) -> Path:
+    candidates = sorted(task_inbox.glob("*.zip"))
+    if not candidates:
+        raise FileNotFoundError(f"No zip files found in {task_inbox}")
+    return min(candidates, key=lambda path: path.stat().st_size)
+
+
+def pick_member(zf: zipfile.ZipFile) -> zipfile.ZipInfo:
+    members = [
+        info
+        for info in zf.infolist()
+        if info.filename.endswith(".mbo.json") and not info.is_dir()
+    ]
+    if not members:
+        raise FileNotFoundError("No .mbo.json members found in zip")
+    return min(members, key=lambda info: info.file_size)
+
+
+def run_smoke(binary: Path, zip_path: Path, member_name: str, keep_json: bool) -> int:
+    if not binary.exists():
+        raise FileNotFoundError(
+            f"Binary not found: {binary}. Build first with `cmake -S . -B build && cmake --build build`."
+        )
+
+    with tempfile.TemporaryDirectory(prefix="back-tester-smoke-") as tmp_dir_name:
+        tmp_dir = Path(tmp_dir_name)
+        extracted = tmp_dir / Path(member_name).name
+
+        with zipfile.ZipFile(zip_path) as zf:
+            with zf.open(member_name) as src, extracted.open("wb") as dst:
+                dst.write(src.read())
+
+        command = [str(binary), str(extracted)]
+        result = subprocess.run(command, capture_output=True, text=True, check=False)
+
+        print(f"zip={zip_path}")
+        print(f"member={member_name}")
+        print(f"json={extracted}")
+        print(f"exit_code={result.returncode}")
+        if result.stdout:
+            print("\n--- stdout (head 20 lines) ---")
+            for line in result.stdout.splitlines()[:20]:
+                print(line)
+        if result.stderr:
+            print("\n--- stderr ---")
+            print(result.stderr.rstrip())
+
+        if keep_json:
+            kept = extracted.with_suffix(extracted.suffix + ".kept")
+            extracted.rename(kept)
+            print(f"\nkept_json={kept}")
+
+        return result.returncode
+
+
+def main() -> int:
+    args = parse_args()
+    zip_path = args.zip_path or pick_zip(args.task_inbox)
+
+    with zipfile.ZipFile(zip_path) as zf:
+        member = args.member or pick_member(zf).filename
+
+    return run_smoke(args.binary, zip_path, member, args.keep_json)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,2 +1,3 @@
 add_subdirectory(common)
+add_subdirectory(ingest)
 add_subdirectory(main)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,3 +1,4 @@
 add_subdirectory(common)
 add_subdirectory(ingest)
+add_subdirectory(lob)
 add_subdirectory(main)

--- a/src/common/MarketDataEvent.cpp
+++ b/src/common/MarketDataEvent.cpp
@@ -1,0 +1,44 @@
+#include "common/MarketDataEvent.hpp"
+
+#include <cstdint>
+#include <cstdio>
+#include <ostream>
+
+namespace cmf {
+
+namespace {
+
+// Render int64 fixed-precision (1e-9) price as decimal with 9 dp, preserving
+// the sentinel. Avoids std::ostream precision fiddling and handles negatives
+// (calendar spreads) correctly without sign-magnitude hazards.
+void writePrice(std::ostream &os, std::int64_t price) {
+  if (price == UNDEF_PRICE) {
+    os << "null";
+    return;
+  }
+  const bool negative = price < 0;
+  // Use unsigned arithmetic to safely negate INT64_MIN (not expected, but
+  // cheap to defend).
+  std::uint64_t mag = negative ? static_cast<std::uint64_t>(-(price + 1)) + 1
+                               : static_cast<std::uint64_t>(price);
+  const std::uint64_t whole = mag / 1'000'000'000ULL;
+  const std::uint64_t frac = mag % 1'000'000'000ULL;
+  char buf[32];
+  std::snprintf(buf, sizeof(buf), "%s%llu.%09llu", negative ? "-" : "",
+                static_cast<unsigned long long>(whole),
+                static_cast<unsigned long long>(frac));
+  os << buf;
+}
+
+} // namespace
+
+std::ostream &operator<<(std::ostream &os, const MarketDataEvent &e) {
+  os << "ts_recv=" << e.ts_recv << " order_id=" << e.order_id
+     << " side=" << static_cast<char>(e.side)
+     << " action=" << static_cast<char>(e.action) << " price=";
+  writePrice(os, e.price);
+  os << " size=" << e.size;
+  return os;
+}
+
+} // namespace cmf

--- a/src/common/MarketDataEvent.hpp
+++ b/src/common/MarketDataEvent.hpp
@@ -1,6 +1,4 @@
 // Databento MBO (L3) record, value type fed to processMarketDataEvent().
-// Fields and semantics per
-// .axxeny-code/tasks/001-hw1/inbox-markdowns/documentation.md
 // Comparator used by the hard-variant k-way merger; unused in easy path.
 
 #pragma once
@@ -70,8 +68,8 @@ constexpr std::strong_ordering operator<=>(const MarketDataEvent &a,
   return mdeOrderKey(a) <=> mdeOrderKey(b);
 }
 
-constexpr bool operator==(const MarketDataEvent &a,
-                          const MarketDataEvent &b) noexcept {
+constexpr bool sameOrderKey(const MarketDataEvent &a,
+                            const MarketDataEvent &b) noexcept {
   return mdeOrderKey(a) == mdeOrderKey(b);
 }
 

--- a/src/common/MarketDataEvent.hpp
+++ b/src/common/MarketDataEvent.hpp
@@ -1,0 +1,82 @@
+// Databento MBO (L3) record, value type fed to processMarketDataEvent().
+// Fields and semantics per
+// .axxeny-code/tasks/001-hw1/inbox-markdowns/documentation.md
+// Comparator used by the hard-variant k-way merger; unused in easy path.
+
+#pragma once
+
+#include <compare>
+#include <cstdint>
+#include <iosfwd>
+#include <limits>
+
+namespace cmf {
+
+inline constexpr std::uint64_t UNDEF_TIMESTAMP =
+    std::numeric_limits<std::uint64_t>::max();
+inline constexpr std::int64_t UNDEF_PRICE =
+    std::numeric_limits<std::int64_t>::max();
+
+enum class MdAction : char {
+  None = 'N',
+  Add = 'A',
+  Modify = 'M',
+  Cancel = 'C',
+  Clear = 'R',
+  Trade = 'T',
+  Fill = 'F',
+};
+
+enum class MdSide : char {
+  None = 'N',
+  Ask = 'A',
+  Bid = 'B',
+};
+
+// Databento rtype for MBO records.
+inline constexpr std::uint8_t RTYPE_MBO = 0xA0;
+
+struct MarketDataEvent {
+  std::uint64_t ts_recv{UNDEF_TIMESTAMP};
+  std::uint64_t ts_event{UNDEF_TIMESTAMP};
+  std::int32_t ts_in_delta{0};
+  std::uint16_t publisher_id{0};
+  std::uint32_t instrument_id{0};
+  std::uint64_t order_id{0};
+  std::int64_t price{UNDEF_PRICE}; // 1e-9 fixed precision
+  std::uint32_t size{0};
+  std::uint32_t sequence{0};
+  std::uint8_t channel_id{0};
+  std::uint8_t flags{0};
+  MdAction action{MdAction::None};
+  MdSide side{MdSide::None};
+};
+
+// Primary ordering matches the Databento "index timestamp" convention and the
+// future k-way merger. Tie-break by publisher_id then sequence so the order is
+// total (safe for priority_queue).
+constexpr auto mdeOrderKey(const MarketDataEvent &e) noexcept {
+  struct Key {
+    std::uint64_t ts_recv;
+    std::uint16_t publisher_id;
+    std::uint32_t sequence;
+    auto operator<=>(const Key &) const = default;
+  };
+  return Key{e.ts_recv, e.publisher_id, e.sequence};
+}
+
+constexpr std::strong_ordering operator<=>(const MarketDataEvent &a,
+                                           const MarketDataEvent &b) noexcept {
+  return mdeOrderKey(a) <=> mdeOrderKey(b);
+}
+
+constexpr bool operator==(const MarketDataEvent &a,
+                          const MarketDataEvent &b) noexcept {
+  return mdeOrderKey(a) == mdeOrderKey(b);
+}
+
+// Print the spec-required fields in a one-line, space-separated format.
+// Format is exercised by both processMarketDataEvent() and tests; keep stable.
+std::ostream &operator<<(std::ostream &os, const MarketDataEvent &e);
+
+} // namespace cmf

--- a/src/ingest/BlockingQueue.hpp
+++ b/src/ingest/BlockingQueue.hpp
@@ -1,0 +1,65 @@
+// Simple bounded blocking queue with close() support.
+//
+// Used by the hard-variant ingest pipeline to connect producer threads,
+// merger threads, and the single dispatcher thread without unbounded growth.
+
+#pragma once
+
+#include <condition_variable>
+#include <cstddef>
+#include <deque>
+#include <mutex>
+#include <utility>
+
+namespace cmf {
+
+template <class T> class BlockingQueue {
+public:
+  explicit BlockingQueue(std::size_t capacity)
+      : capacity_{capacity == 0 ? 1 : capacity} {}
+
+  BlockingQueue(const BlockingQueue &) = delete;
+  BlockingQueue &operator=(const BlockingQueue &) = delete;
+
+  bool push(T value) {
+    std::unique_lock lock{mutex_};
+    not_full_.wait(lock, [&] { return closed_ || queue_.size() < capacity_; });
+    if (closed_) {
+      return false;
+    }
+    queue_.push_back(std::move(value));
+    lock.unlock();
+    not_empty_.notify_one();
+    return true;
+  }
+
+  bool pop(T &out) {
+    std::unique_lock lock{mutex_};
+    not_empty_.wait(lock, [&] { return closed_ || !queue_.empty(); });
+    if (queue_.empty()) {
+      return false;
+    }
+    out = std::move(queue_.front());
+    queue_.pop_front();
+    lock.unlock();
+    not_full_.notify_one();
+    return true;
+  }
+
+  void close() {
+    std::lock_guard lock{mutex_};
+    closed_ = true;
+    not_empty_.notify_all();
+    not_full_.notify_all();
+  }
+
+private:
+  std::size_t capacity_;
+  std::deque<T> queue_;
+  bool closed_ = false;
+  std::mutex mutex_;
+  std::condition_variable not_empty_;
+  std::condition_variable not_full_;
+};
+
+} // namespace cmf

--- a/src/ingest/CMakeLists.txt
+++ b/src/ingest/CMakeLists.txt
@@ -1,0 +1,8 @@
+set(TARGET back-tester-ingest)
+file(GLOB SRC CONFIGURE_DEPENDS *.cpp)
+
+add_library(${TARGET} STATIC ${SRC})
+target_link_libraries(${TARGET} PUBLIC
+    back-tester-common
+    simdjson-static-lib
+)

--- a/src/ingest/FolderIngest.cpp
+++ b/src/ingest/FolderIngest.cpp
@@ -4,6 +4,7 @@
 
 #include <algorithm>
 #include <atomic>
+#include <cassert>
 #include <chrono>
 #include <compare>
 #include <cstdint>
@@ -146,7 +147,11 @@ public:
     return true;
   }
 
-  const OrderedEvent &current() const noexcept { return current_.events[offset_]; }
+  // Precondition: ensureCurrent() was called and returned true.
+  const OrderedEvent &current() const noexcept {
+    assert(offset_ < current_.events.size());
+    return current_.events[offset_];
+  }
 
   void advance() noexcept { ++offset_; }
 
@@ -351,10 +356,11 @@ FolderIngestStats ingestFolder(const std::filesystem::path &folder,
                                const MarketDataEventConsumer &consumer,
                                FolderIngestOptions options) {
   if (options.queue_capacity == 0) {
-    options.queue_capacity = 1;
+    throw std::invalid_argument(
+        "ingestFolder: queue_capacity must be >= 1");
   }
   if (options.batch_size == 0) {
-    options.batch_size = 1;
+    throw std::invalid_argument("ingestFolder: batch_size must be >= 1");
   }
 
   const auto files = listNdjsonFiles(folder);
@@ -433,6 +439,7 @@ FolderIngestStats ingestFolder(const std::filesystem::path &folder,
   for (const auto &producer : producer_results) {
     stats.skipped_rtype += producer.stats.skipped_rtype;
     stats.skipped_parse += producer.stats.skipped_parse;
+    stats.producer_out_of_order_ts_recv += producer.stats.out_of_order_ts_recv;
   }
   return stats;
 }

--- a/src/ingest/FolderIngest.cpp
+++ b/src/ingest/FolderIngest.cpp
@@ -6,14 +6,15 @@
 #include <atomic>
 #include <chrono>
 #include <compare>
+#include <cstdint>
 #include <exception>
 #include <memory>
 #include <mutex>
-#include <optional>
 #include <queue>
 #include <stdexcept>
 #include <thread>
 #include <utility>
+#include <vector>
 
 namespace cmf {
 
@@ -23,11 +24,15 @@ using Clock = std::chrono::steady_clock;
 
 struct OrderedEvent {
   MarketDataEvent event;
-  std::size_t source_index = 0;
+  std::uint32_t source_index = 0;
 };
 
-using EventQueue = BlockingQueue<OrderedEvent>;
-using EventQueuePtr = std::shared_ptr<EventQueue>;
+struct EventBlock {
+  std::vector<OrderedEvent> events;
+};
+
+using BlockQueue = BlockingQueue<EventBlock>;
+using BlockQueuePtr = std::shared_ptr<BlockQueue>;
 
 struct ProducerResult {
   IngestStats stats{};
@@ -56,7 +61,7 @@ bool orderedEventLess(const OrderedEvent &lhs,
 
 class RunControl {
 public:
-  void registerQueue(const EventQueuePtr &queue) {
+  void registerQueue(const BlockQueuePtr &queue) {
     std::lock_guard lock{queues_mutex_};
     queues_.push_back(queue);
   }
@@ -73,7 +78,7 @@ public:
   }
 
   void closeAllQueues() {
-    std::vector<EventQueuePtr> snapshot;
+    std::vector<BlockQueuePtr> snapshot;
     {
       std::lock_guard lock{queues_mutex_};
       snapshot = queues_;
@@ -99,53 +104,76 @@ private:
   std::mutex queues_mutex_;
   std::exception_ptr error_;
   std::atomic<bool> cancelled_{false};
-  std::vector<EventQueuePtr> queues_;
+  std::vector<BlockQueuePtr> queues_;
 };
 
-EventQueuePtr makeQueue(std::size_t capacity, RunControl &control) {
-  auto queue = std::make_shared<EventQueue>(capacity);
+BlockQueuePtr makeQueue(std::size_t capacity, RunControl &control) {
+  auto queue = std::make_shared<BlockQueue>(capacity);
   control.registerQueue(queue);
   return queue;
 }
 
-void producerThread(const std::filesystem::path &path, std::size_t source_index,
-                    const EventQueuePtr &output, ProducerResult &result,
-                    RunControl &control) {
+EventBlock makeBlock(std::size_t batch_size) {
+  EventBlock block;
+  block.events.reserve(batch_size);
+  return block;
+}
+
+bool flushBlock(const BlockQueuePtr &queue, EventBlock &block,
+                std::size_t batch_size) {
+  if (block.events.empty()) {
+    return true;
+  }
+  if (!queue->push(std::move(block))) {
+    return false;
+  }
+  block = makeBlock(batch_size);
+  return true;
+}
+
+class StreamCursor {
+public:
+  explicit StreamCursor(BlockQueuePtr queue) : queue_{std::move(queue)} {}
+
+  bool ensureCurrent() {
+    while (offset_ >= current_.events.size()) {
+      current_ = EventBlock{};
+      offset_ = 0;
+      if (!queue_->pop(current_)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  const OrderedEvent &current() const noexcept { return current_.events[offset_]; }
+
+  void advance() noexcept { ++offset_; }
+
+private:
+  BlockQueuePtr queue_;
+  EventBlock current_;
+  std::size_t offset_ = 0;
+};
+
+void producerThread(const std::filesystem::path &path, std::uint32_t source_index,
+                    const BlockQueuePtr &output, ProducerResult &result,
+                    std::size_t batch_size, RunControl &control) {
   try {
+    EventBlock block = makeBlock(batch_size);
     result.stats = parseNdjsonFile(
         path, MarketDataEventVisitor{[&](const MarketDataEvent &event) {
           if (control.cancelled()) {
             return false;
           }
-          return output->push(OrderedEvent{event, source_index});
+          block.events.push_back(OrderedEvent{event, source_index});
+          if (block.events.size() < batch_size) {
+            return true;
+          }
+          return flushBlock(output, block, batch_size);
         }});
-  } catch (...) {
-    control.captureCurrentException();
-  }
-  output->close();
-}
-
-void mergeTwoQueues(const EventQueuePtr &left, const EventQueuePtr &right,
-                    const EventQueuePtr &output, RunControl &control) {
-  try {
-    OrderedEvent left_value{};
-    OrderedEvent right_value{};
-    bool has_left = left->pop(left_value);
-    bool has_right = right->pop(right_value);
-
-    while (!control.cancelled() && (has_left || has_right)) {
-      if (!has_right ||
-          (has_left && !orderedEventLess(right_value, left_value))) {
-        if (!output->push(left_value)) {
-          break;
-        }
-        has_left = left->pop(left_value);
-      } else {
-        if (!output->push(right_value)) {
-          break;
-        }
-        has_right = right->pop(right_value);
-      }
+    if (!control.cancelled()) {
+      flushBlock(output, block, batch_size);
     }
   } catch (...) {
     control.captureCurrentException();
@@ -153,11 +181,50 @@ void mergeTwoQueues(const EventQueuePtr &left, const EventQueuePtr &right,
   output->close();
 }
 
-void flatMergerThread(const std::vector<EventQueuePtr> &inputs,
-                      const EventQueuePtr &output, RunControl &control) {
+void mergeTwoQueues(const BlockQueuePtr &left, const BlockQueuePtr &right,
+                    const BlockQueuePtr &output, std::size_t batch_size,
+                    RunControl &control) {
+  try {
+    StreamCursor left_cursor{left};
+    StreamCursor right_cursor{right};
+    bool has_left = left_cursor.ensureCurrent();
+    bool has_right = right_cursor.ensureCurrent();
+    EventBlock output_block = makeBlock(batch_size);
+
+    while (!control.cancelled() && (has_left || has_right)) {
+      if (!has_right ||
+          (has_left &&
+           !orderedEventLess(right_cursor.current(), left_cursor.current()))) {
+        output_block.events.push_back(left_cursor.current());
+        left_cursor.advance();
+        has_left = left_cursor.ensureCurrent();
+      } else {
+        output_block.events.push_back(right_cursor.current());
+        right_cursor.advance();
+        has_right = right_cursor.ensureCurrent();
+      }
+
+      if (output_block.events.size() == batch_size &&
+          !flushBlock(output, output_block, batch_size)) {
+        break;
+      }
+    }
+
+    if (!control.cancelled()) {
+      flushBlock(output, output_block, batch_size);
+    }
+  } catch (...) {
+    control.captureCurrentException();
+  }
+  output->close();
+}
+
+void flatMergerThread(const std::vector<BlockQueuePtr> &inputs,
+                      const BlockQueuePtr &output, std::size_t batch_size,
+                      RunControl &control) {
   struct HeapEntry {
     OrderedEvent ordered_event;
-    std::size_t source_index = 0;
+    std::size_t stream_index = 0;
   };
 
   struct HeapGreater {
@@ -167,25 +234,37 @@ void flatMergerThread(const std::vector<EventQueuePtr> &inputs,
   };
 
   try {
+    std::vector<StreamCursor> cursors;
+    cursors.reserve(inputs.size());
     std::priority_queue<HeapEntry, std::vector<HeapEntry>, HeapGreater> heap;
+
     for (std::size_t i = 0; i < inputs.size(); ++i) {
-      OrderedEvent next{};
-      if (inputs[i]->pop(next)) {
-        heap.push(HeapEntry{next, i});
+      cursors.emplace_back(inputs[i]);
+      if (cursors.back().ensureCurrent()) {
+        heap.push(HeapEntry{cursors.back().current(), i});
       }
     }
 
+    EventBlock output_block = makeBlock(batch_size);
     while (!control.cancelled() && !heap.empty()) {
       HeapEntry top = heap.top();
       heap.pop();
-      if (!output->push(top.ordered_event)) {
-        break;
+      output_block.events.push_back(top.ordered_event);
+
+      auto &cursor = cursors[top.stream_index];
+      cursor.advance();
+      if (cursor.ensureCurrent()) {
+        heap.push(HeapEntry{cursor.current(), top.stream_index});
       }
 
-      OrderedEvent next{};
-      if (inputs[top.source_index]->pop(next)) {
-        heap.push(HeapEntry{next, top.source_index});
+      if (output_block.events.size() == batch_size &&
+          !flushBlock(output, output_block, batch_size)) {
+        break;
       }
+    }
+
+    if (!control.cancelled()) {
+      flushBlock(output, output_block, batch_size);
     }
   } catch (...) {
     control.captureCurrentException();
@@ -193,22 +272,24 @@ void flatMergerThread(const std::vector<EventQueuePtr> &inputs,
   output->close();
 }
 
-DispatchResult dispatchQueue(const EventQueuePtr &input,
+DispatchResult dispatchQueue(const BlockQueuePtr &input,
                              const MarketDataEventConsumer &consumer,
                              RunControl &control) {
   DispatchResult result{};
   try {
-    OrderedEvent ordered{};
-    while (input->pop(ordered)) {
-      const auto &event = ordered.event;
-      if (result.total == 0) {
-        result.first_ts_recv = event.ts_recv;
-      } else if (event.ts_recv < result.last_ts_recv) {
-        ++result.out_of_order_ts_recv;
+    EventBlock block;
+    while (input->pop(block)) {
+      for (const auto &ordered : block.events) {
+        const auto &event = ordered.event;
+        if (result.total == 0) {
+          result.first_ts_recv = event.ts_recv;
+        } else if (event.ts_recv < result.last_ts_recv) {
+          ++result.out_of_order_ts_recv;
+        }
+        result.last_ts_recv = event.ts_recv;
+        ++result.total;
+        consumer(event);
       }
-      result.last_ts_recv = event.ts_recv;
-      ++result.total;
-      consumer(event);
     }
   } catch (...) {
     control.captureCurrentException();
@@ -269,12 +350,19 @@ FolderIngestStats ingestFolder(const std::filesystem::path &folder,
                                MergeStrategy strategy,
                                const MarketDataEventConsumer &consumer,
                                FolderIngestOptions options) {
+  if (options.queue_capacity == 0) {
+    options.queue_capacity = 1;
+  }
+  if (options.batch_size == 0) {
+    options.batch_size = 1;
+  }
+
   const auto files = listNdjsonFiles(folder);
   RunControl control;
   std::vector<std::thread> producer_threads;
   std::vector<std::thread> merger_threads;
   std::vector<ProducerResult> producer_results(files.size());
-  std::vector<EventQueuePtr> producer_queues;
+  std::vector<BlockQueuePtr> producer_queues;
   producer_queues.reserve(files.size());
 
   for (std::size_t i = 0; i < files.size(); ++i) {
@@ -284,21 +372,23 @@ FolderIngestStats ingestFolder(const std::filesystem::path &folder,
   const auto start = Clock::now();
 
   for (std::size_t i = 0; i < files.size(); ++i) {
-    producer_threads.emplace_back(producerThread, files[i], i,
+    producer_threads.emplace_back(producerThread, files[i],
+                                  static_cast<std::uint32_t>(i),
                                   producer_queues[i],
                                   std::ref(producer_results[i]),
-                                  std::ref(control));
+                                  options.batch_size, std::ref(control));
   }
 
-  EventQueuePtr final_queue;
+  BlockQueuePtr final_queue;
   if (strategy == MergeStrategy::Flat) {
     final_queue = makeQueue(options.queue_capacity, control);
     merger_threads.emplace_back(flatMergerThread, std::cref(producer_queues),
-                                final_queue, std::ref(control));
+                                final_queue, options.batch_size,
+                                std::ref(control));
   } else {
-    std::vector<EventQueuePtr> current = producer_queues;
+    std::vector<BlockQueuePtr> current = producer_queues;
     while (current.size() > 1) {
-      std::vector<EventQueuePtr> next_level;
+      std::vector<BlockQueuePtr> next_level;
       next_level.reserve((current.size() + 1) / 2);
       for (std::size_t i = 0; i < current.size(); i += 2) {
         if (i + 1 == current.size()) {
@@ -307,7 +397,8 @@ FolderIngestStats ingestFolder(const std::filesystem::path &folder,
         }
         auto merged = makeQueue(options.queue_capacity, control);
         merger_threads.emplace_back(mergeTwoQueues, current[i], current[i + 1],
-                                    merged, std::ref(control));
+                                    merged, options.batch_size,
+                                    std::ref(control));
         next_level.push_back(merged);
       }
       current = std::move(next_level);

--- a/src/ingest/FolderIngest.cpp
+++ b/src/ingest/FolderIngest.cpp
@@ -1,0 +1,349 @@
+#include "ingest/FolderIngest.hpp"
+
+#include "ingest/BlockingQueue.hpp"
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <compare>
+#include <exception>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <queue>
+#include <stdexcept>
+#include <thread>
+#include <utility>
+
+namespace cmf {
+
+namespace {
+
+using Clock = std::chrono::steady_clock;
+
+struct OrderedEvent {
+  MarketDataEvent event;
+  std::size_t source_index = 0;
+};
+
+using EventQueue = BlockingQueue<OrderedEvent>;
+using EventQueuePtr = std::shared_ptr<EventQueue>;
+
+struct ProducerResult {
+  IngestStats stats{};
+};
+
+struct DispatchResult {
+  std::size_t total = 0;
+  std::size_t out_of_order_ts_recv = 0;
+  std::uint64_t first_ts_recv = UNDEF_TIMESTAMP;
+  std::uint64_t last_ts_recv = UNDEF_TIMESTAMP;
+};
+
+std::strong_ordering compareOrderedEvent(const OrderedEvent &lhs,
+                                         const OrderedEvent &rhs) noexcept {
+  if (const auto by_event = mdeOrderKey(lhs.event) <=> mdeOrderKey(rhs.event);
+      by_event != 0) {
+    return by_event;
+  }
+  return lhs.source_index <=> rhs.source_index;
+}
+
+bool orderedEventLess(const OrderedEvent &lhs,
+                      const OrderedEvent &rhs) noexcept {
+  return compareOrderedEvent(lhs, rhs) < 0;
+}
+
+class RunControl {
+public:
+  void registerQueue(const EventQueuePtr &queue) {
+    std::lock_guard lock{queues_mutex_};
+    queues_.push_back(queue);
+  }
+
+  void captureCurrentException() {
+    {
+      std::lock_guard lock{error_mutex_};
+      if (!error_) {
+        error_ = std::current_exception();
+      }
+    }
+    cancelled_.store(true);
+    closeAllQueues();
+  }
+
+  void closeAllQueues() {
+    std::vector<EventQueuePtr> snapshot;
+    {
+      std::lock_guard lock{queues_mutex_};
+      snapshot = queues_;
+    }
+    for (const auto &queue : snapshot) {
+      if (queue) {
+        queue->close();
+      }
+    }
+  }
+
+  bool cancelled() const noexcept { return cancelled_.load(); }
+
+  void rethrowIfNeeded() const {
+    std::lock_guard lock{error_mutex_};
+    if (error_) {
+      std::rethrow_exception(error_);
+    }
+  }
+
+private:
+  mutable std::mutex error_mutex_;
+  std::mutex queues_mutex_;
+  std::exception_ptr error_;
+  std::atomic<bool> cancelled_{false};
+  std::vector<EventQueuePtr> queues_;
+};
+
+EventQueuePtr makeQueue(std::size_t capacity, RunControl &control) {
+  auto queue = std::make_shared<EventQueue>(capacity);
+  control.registerQueue(queue);
+  return queue;
+}
+
+void producerThread(const std::filesystem::path &path, std::size_t source_index,
+                    const EventQueuePtr &output, ProducerResult &result,
+                    RunControl &control) {
+  try {
+    result.stats = parseNdjsonFile(
+        path, MarketDataEventVisitor{[&](const MarketDataEvent &event) {
+          if (control.cancelled()) {
+            return false;
+          }
+          return output->push(OrderedEvent{event, source_index});
+        }});
+  } catch (...) {
+    control.captureCurrentException();
+  }
+  output->close();
+}
+
+void mergeTwoQueues(const EventQueuePtr &left, const EventQueuePtr &right,
+                    const EventQueuePtr &output, RunControl &control) {
+  try {
+    OrderedEvent left_value{};
+    OrderedEvent right_value{};
+    bool has_left = left->pop(left_value);
+    bool has_right = right->pop(right_value);
+
+    while (!control.cancelled() && (has_left || has_right)) {
+      if (!has_right ||
+          (has_left && !orderedEventLess(right_value, left_value))) {
+        if (!output->push(left_value)) {
+          break;
+        }
+        has_left = left->pop(left_value);
+      } else {
+        if (!output->push(right_value)) {
+          break;
+        }
+        has_right = right->pop(right_value);
+      }
+    }
+  } catch (...) {
+    control.captureCurrentException();
+  }
+  output->close();
+}
+
+void flatMergerThread(const std::vector<EventQueuePtr> &inputs,
+                      const EventQueuePtr &output, RunControl &control) {
+  struct HeapEntry {
+    OrderedEvent ordered_event;
+    std::size_t source_index = 0;
+  };
+
+  struct HeapGreater {
+    bool operator()(const HeapEntry &lhs, const HeapEntry &rhs) const noexcept {
+      return orderedEventLess(rhs.ordered_event, lhs.ordered_event);
+    }
+  };
+
+  try {
+    std::priority_queue<HeapEntry, std::vector<HeapEntry>, HeapGreater> heap;
+    for (std::size_t i = 0; i < inputs.size(); ++i) {
+      OrderedEvent next{};
+      if (inputs[i]->pop(next)) {
+        heap.push(HeapEntry{next, i});
+      }
+    }
+
+    while (!control.cancelled() && !heap.empty()) {
+      HeapEntry top = heap.top();
+      heap.pop();
+      if (!output->push(top.ordered_event)) {
+        break;
+      }
+
+      OrderedEvent next{};
+      if (inputs[top.source_index]->pop(next)) {
+        heap.push(HeapEntry{next, top.source_index});
+      }
+    }
+  } catch (...) {
+    control.captureCurrentException();
+  }
+  output->close();
+}
+
+DispatchResult dispatchQueue(const EventQueuePtr &input,
+                             const MarketDataEventConsumer &consumer,
+                             RunControl &control) {
+  DispatchResult result{};
+  try {
+    OrderedEvent ordered{};
+    while (input->pop(ordered)) {
+      const auto &event = ordered.event;
+      if (result.total == 0) {
+        result.first_ts_recv = event.ts_recv;
+      } else if (event.ts_recv < result.last_ts_recv) {
+        ++result.out_of_order_ts_recv;
+      }
+      result.last_ts_recv = event.ts_recv;
+      ++result.total;
+      consumer(event);
+    }
+  } catch (...) {
+    control.captureCurrentException();
+  }
+  return result;
+}
+
+void joinAll(std::vector<std::thread> &threads) {
+  for (auto &thread : threads) {
+    if (thread.joinable()) {
+      thread.join();
+    }
+  }
+}
+
+} // namespace
+
+const char *mergeStrategyName(MergeStrategy strategy) noexcept {
+  switch (strategy) {
+  case MergeStrategy::Flat:
+    return "flat";
+  case MergeStrategy::Hierarchy:
+    return "hierarchy";
+  }
+  return "unknown";
+}
+
+std::vector<std::filesystem::path>
+listNdjsonFiles(const std::filesystem::path &folder) {
+  if (!std::filesystem::exists(folder)) {
+    throw std::runtime_error("ingestFolder: path does not exist: " +
+                             folder.string());
+  }
+  if (!std::filesystem::is_directory(folder)) {
+    throw std::runtime_error("ingestFolder: expected directory: " +
+                             folder.string());
+  }
+
+  std::vector<std::filesystem::path> files;
+  for (const auto &entry : std::filesystem::directory_iterator(folder)) {
+    if (!entry.is_regular_file()) {
+      continue;
+    }
+    const auto ext = entry.path().extension().string();
+    if (ext == ".json" || ext == ".ndjson") {
+      files.push_back(entry.path());
+    }
+  }
+  std::sort(files.begin(), files.end());
+  if (files.empty()) {
+    throw std::runtime_error("ingestFolder: no .json or .ndjson files in " +
+                             folder.string());
+  }
+  return files;
+}
+
+FolderIngestStats ingestFolder(const std::filesystem::path &folder,
+                               MergeStrategy strategy,
+                               const MarketDataEventConsumer &consumer,
+                               FolderIngestOptions options) {
+  const auto files = listNdjsonFiles(folder);
+  RunControl control;
+  std::vector<std::thread> producer_threads;
+  std::vector<std::thread> merger_threads;
+  std::vector<ProducerResult> producer_results(files.size());
+  std::vector<EventQueuePtr> producer_queues;
+  producer_queues.reserve(files.size());
+
+  for (std::size_t i = 0; i < files.size(); ++i) {
+    producer_queues.push_back(makeQueue(options.queue_capacity, control));
+  }
+
+  const auto start = Clock::now();
+
+  for (std::size_t i = 0; i < files.size(); ++i) {
+    producer_threads.emplace_back(producerThread, files[i], i,
+                                  producer_queues[i],
+                                  std::ref(producer_results[i]),
+                                  std::ref(control));
+  }
+
+  EventQueuePtr final_queue;
+  if (strategy == MergeStrategy::Flat) {
+    final_queue = makeQueue(options.queue_capacity, control);
+    merger_threads.emplace_back(flatMergerThread, std::cref(producer_queues),
+                                final_queue, std::ref(control));
+  } else {
+    std::vector<EventQueuePtr> current = producer_queues;
+    while (current.size() > 1) {
+      std::vector<EventQueuePtr> next_level;
+      next_level.reserve((current.size() + 1) / 2);
+      for (std::size_t i = 0; i < current.size(); i += 2) {
+        if (i + 1 == current.size()) {
+          next_level.push_back(current[i]);
+          continue;
+        }
+        auto merged = makeQueue(options.queue_capacity, control);
+        merger_threads.emplace_back(mergeTwoQueues, current[i], current[i + 1],
+                                    merged, std::ref(control));
+        next_level.push_back(merged);
+      }
+      current = std::move(next_level);
+    }
+    final_queue = current.front();
+  }
+
+  DispatchResult dispatch{};
+  std::thread dispatcher_thread([&] {
+    dispatch = dispatchQueue(final_queue, consumer, control);
+  });
+
+  joinAll(producer_threads);
+  joinAll(merger_threads);
+  if (dispatcher_thread.joinable()) {
+    dispatcher_thread.join();
+  }
+
+  const auto elapsed =
+      std::chrono::duration<double>(Clock::now() - start).count();
+
+  control.rethrowIfNeeded();
+
+  FolderIngestStats stats{};
+  stats.strategy = strategy;
+  stats.files = files.size();
+  stats.total = dispatch.total;
+  stats.out_of_order_ts_recv = dispatch.out_of_order_ts_recv;
+  stats.first_ts_recv = dispatch.first_ts_recv;
+  stats.last_ts_recv = dispatch.last_ts_recv;
+  stats.elapsed_sec = elapsed;
+  for (const auto &producer : producer_results) {
+    stats.skipped_rtype += producer.stats.skipped_rtype;
+    stats.skipped_parse += producer.stats.skipped_parse;
+  }
+  return stats;
+}
+
+} // namespace cmf

--- a/src/ingest/FolderIngest.hpp
+++ b/src/ingest/FolderIngest.hpp
@@ -23,6 +23,10 @@ enum class MergeStrategy {
 
 const char *mergeStrategyName(MergeStrategy strategy) noexcept;
 
+// Defaults tuned against the 44-file real Eurex benchmark: 512-event blocks
+// keep per-flush sync overhead low without blowing dispatcher latency, and a
+// 64-block queue is enough to absorb producer jitter without unbounded memory.
+// Zero is rejected (see ingestFolder) so downstream code can assume >= 1.
 struct FolderIngestOptions {
   std::size_t queue_capacity = 64;
   std::size_t batch_size = 512;
@@ -34,7 +38,12 @@ struct FolderIngestStats {
   std::size_t total = 0;
   std::size_t skipped_rtype = 0;
   std::size_t skipped_parse = 0;
+  // Out-of-order count on the merged/dispatched stream — non-zero would
+  // indicate a merge bug, not an input defect.
   std::size_t out_of_order_ts_recv = 0;
+  // Sum of per-producer within-file out-of-order events — diagnostic on
+  // input quality; independent of merge correctness.
+  std::size_t producer_out_of_order_ts_recv = 0;
   std::uint64_t first_ts_recv = UNDEF_TIMESTAMP;
   std::uint64_t last_ts_recv = UNDEF_TIMESTAMP;
   double elapsed_sec = 0.0;

--- a/src/ingest/FolderIngest.hpp
+++ b/src/ingest/FolderIngest.hpp
@@ -24,7 +24,8 @@ enum class MergeStrategy {
 const char *mergeStrategyName(MergeStrategy strategy) noexcept;
 
 struct FolderIngestOptions {
-  std::size_t queue_capacity = 1024;
+  std::size_t queue_capacity = 64;
+  std::size_t batch_size = 512;
 };
 
 struct FolderIngestStats {

--- a/src/ingest/FolderIngest.hpp
+++ b/src/ingest/FolderIngest.hpp
@@ -1,0 +1,54 @@
+// Multi-file hard-variant ingest pipeline.
+//
+// One producer thread reads each file into a per-file queue. Strategy-specific
+// merger threads combine those sorted streams into one final queue, which a
+// single dispatcher thread drains in chronological order.
+
+#pragma once
+
+#include "common/MarketDataEvent.hpp"
+#include "ingest/NdjsonReader.hpp"
+
+#include <cstddef>
+#include <cstdint>
+#include <filesystem>
+#include <vector>
+
+namespace cmf {
+
+enum class MergeStrategy {
+  Flat,
+  Hierarchy,
+};
+
+const char *mergeStrategyName(MergeStrategy strategy) noexcept;
+
+struct FolderIngestOptions {
+  std::size_t queue_capacity = 1024;
+};
+
+struct FolderIngestStats {
+  MergeStrategy strategy{MergeStrategy::Flat};
+  std::size_t files = 0;
+  std::size_t total = 0;
+  std::size_t skipped_rtype = 0;
+  std::size_t skipped_parse = 0;
+  std::size_t out_of_order_ts_recv = 0;
+  std::uint64_t first_ts_recv = UNDEF_TIMESTAMP;
+  std::uint64_t last_ts_recv = UNDEF_TIMESTAMP;
+  double elapsed_sec = 0.0;
+
+  double msgsPerSec() const noexcept {
+    return elapsed_sec > 0.0 ? static_cast<double>(total) / elapsed_sec : 0.0;
+  }
+};
+
+std::vector<std::filesystem::path>
+listNdjsonFiles(const std::filesystem::path &folder);
+
+FolderIngestStats ingestFolder(const std::filesystem::path &folder,
+                               MergeStrategy strategy,
+                               const MarketDataEventConsumer &consumer,
+                               FolderIngestOptions options = {});
+
+} // namespace cmf

--- a/src/ingest/MboDecoder.cpp
+++ b/src/ingest/MboDecoder.cpp
@@ -1,0 +1,448 @@
+#include "ingest/MboDecoder.hpp"
+
+#include <simdjson.h>
+
+#include <cctype>
+#include <charconv>
+#include <cstdint>
+#include <limits>
+#include <string_view>
+#include <system_error>
+
+namespace cmf {
+
+namespace {
+
+// Databento JSON sometimes emits 64-bit integers as strings to avoid double
+// rounding in downstream parsers. Accept both shapes uniformly.
+
+template <class Int> bool parseIntFromString(std::string_view s, Int &out) {
+  const char *first = s.data();
+  const char *last = first + s.size();
+  if (first != last && *first == '+') {
+    ++first;
+  }
+  auto [p, ec] = std::from_chars(first, last, out);
+  return ec == std::errc() && p == last;
+}
+
+bool readU64(simdjson::dom::element elem, std::uint64_t &out) {
+  if (elem.is_uint64()) {
+    out = elem.get_uint64().value();
+    return true;
+  }
+  if (elem.is_int64()) {
+    std::int64_t v = elem.get_int64().value();
+    if (v < 0) {
+      return false;
+    }
+    out = static_cast<std::uint64_t>(v);
+    return true;
+  }
+  if (elem.is_string()) {
+    return parseIntFromString(elem.get_string().value(), out);
+  }
+  return false;
+}
+
+bool readI64(simdjson::dom::element elem, std::int64_t &out) {
+  if (elem.is_int64()) {
+    out = elem.get_int64().value();
+    return true;
+  }
+  if (elem.is_uint64()) {
+    std::uint64_t v = elem.get_uint64().value();
+    if (v >
+        static_cast<std::uint64_t>(std::numeric_limits<std::int64_t>::max())) {
+      return false;
+    }
+    out = static_cast<std::int64_t>(v);
+    return true;
+  }
+  if (elem.is_string()) {
+    return parseIntFromString(elem.get_string().value(), out);
+  }
+  return false;
+}
+
+template <class UInt> bool assignUnsigned(std::uint64_t value, UInt &out) {
+  if (value > static_cast<std::uint64_t>(std::numeric_limits<UInt>::max())) {
+    return false;
+  }
+  out = static_cast<UInt>(value);
+  return true;
+}
+
+template <class Int> bool assignSigned(std::int64_t value, Int &out) {
+  if (value < static_cast<std::int64_t>(std::numeric_limits<Int>::min()) ||
+      value > static_cast<std::int64_t>(std::numeric_limits<Int>::max())) {
+    return false;
+  }
+  out = static_cast<Int>(value);
+  return true;
+}
+
+constexpr std::uint64_t kNanosPerSecond = 1'000'000'000ULL;
+
+bool parseDigits(std::string_view s, std::size_t pos, std::size_t count,
+                 unsigned &out) {
+  if (pos + count > s.size()) {
+    return false;
+  }
+  unsigned value = 0;
+  for (std::size_t i = 0; i < count; ++i) {
+    const unsigned char ch = static_cast<unsigned char>(s[pos + i]);
+    if (!std::isdigit(ch)) {
+      return false;
+    }
+    value = value * 10U + static_cast<unsigned>(ch - '0');
+  }
+  out = value;
+  return true;
+}
+
+constexpr std::int64_t daysFromCivil(int year, unsigned month,
+                                     unsigned day) noexcept {
+  year -= month <= 2;
+  const int era = (year >= 0 ? year : year - 399) / 400;
+  const unsigned yoe = static_cast<unsigned>(year - era * 400);
+  const unsigned shiftedMonth = month > 2 ? month - 3 : month + 9;
+  const unsigned doy = (153 * shiftedMonth + 2) / 5 + day - 1;
+  const unsigned doe = yoe * 365 + yoe / 4 - yoe / 100 + doy;
+  return era * 146097 + static_cast<int>(doe) - 719468;
+}
+
+bool parseIso8601Timestamp(std::string_view s, std::uint64_t &out) {
+  if (s.size() < 20 || s[4] != '-' || s[7] != '-' || s[10] != 'T' ||
+      s[13] != ':' || s[16] != ':' || s.back() != 'Z') {
+    return false;
+  }
+
+  unsigned year = 0;
+  unsigned month = 0;
+  unsigned day = 0;
+  unsigned hour = 0;
+  unsigned minute = 0;
+  unsigned second = 0;
+  if (!parseDigits(s, 0, 4, year) || !parseDigits(s, 5, 2, month) ||
+      !parseDigits(s, 8, 2, day) || !parseDigits(s, 11, 2, hour) ||
+      !parseDigits(s, 14, 2, minute) || !parseDigits(s, 17, 2, second)) {
+    return false;
+  }
+  if (month < 1 || month > 12 || day < 1 || day > 31 || hour > 23 ||
+      minute > 59 || second > 59) {
+    return false;
+  }
+
+  std::uint64_t nanos = 0;
+  if (s.size() > 20) {
+    if (s[19] != '.') {
+      return false;
+    }
+    std::size_t pos = 20;
+    std::size_t digits = 0;
+    while (pos < s.size() - 1) {
+      const unsigned char ch = static_cast<unsigned char>(s[pos]);
+      if (!std::isdigit(ch) || digits == 9) {
+        return false;
+      }
+      nanos = nanos * 10ULL + static_cast<std::uint64_t>(ch - '0');
+      ++pos;
+      ++digits;
+    }
+    if (digits == 0) {
+      return false;
+    }
+    while (digits < 9) {
+      nanos *= 10ULL;
+      ++digits;
+    }
+  }
+
+  const std::int64_t days = daysFromCivil(static_cast<int>(year), month, day);
+  if (days < 0) {
+    return false;
+  }
+  const std::uint64_t seconds = static_cast<std::uint64_t>(days) * 86400ULL +
+                                static_cast<std::uint64_t>(hour) * 3600ULL +
+                                static_cast<std::uint64_t>(minute) * 60ULL +
+                                static_cast<std::uint64_t>(second);
+  out = seconds * kNanosPerSecond + nanos;
+  return true;
+}
+
+bool readTimestamp(simdjson::dom::element elem, std::uint64_t &out) {
+  if (readU64(elem, out)) {
+    return true;
+  }
+  if (!elem.is_string()) {
+    return false;
+  }
+  const std::string_view s = elem.get_string().value();
+  return parseIso8601Timestamp(s, out);
+}
+
+bool parseFixedPointPrice(std::string_view s, std::int64_t &out) {
+  if (s.empty()) {
+    return false;
+  }
+
+  bool negative = false;
+  std::size_t pos = 0;
+  if (s[pos] == '+' || s[pos] == '-') {
+    negative = s[pos] == '-';
+    ++pos;
+  }
+  if (pos == s.size()) {
+    return false;
+  }
+
+  std::uint64_t whole = 0;
+  std::size_t wholeDigits = 0;
+  while (pos < s.size() && std::isdigit(static_cast<unsigned char>(s[pos]))) {
+    const auto digit = static_cast<std::uint64_t>(s[pos] - '0');
+    if (whole > (std::numeric_limits<std::uint64_t>::max() - digit) / 10ULL) {
+      return false;
+    }
+    whole = whole * 10ULL + digit;
+    ++pos;
+    ++wholeDigits;
+  }
+  if (wholeDigits == 0) {
+    return false;
+  }
+
+  std::uint64_t frac = 0;
+  std::size_t fracDigits = 0;
+  if (pos < s.size()) {
+    if (s[pos] != '.') {
+      return false;
+    }
+    ++pos;
+    while (pos < s.size()) {
+      const unsigned char ch = static_cast<unsigned char>(s[pos]);
+      if (!std::isdigit(ch) || fracDigits == 9) {
+        return false;
+      }
+      frac = frac * 10ULL + static_cast<std::uint64_t>(ch - '0');
+      ++pos;
+      ++fracDigits;
+    }
+    while (fracDigits < 9) {
+      frac *= 10ULL;
+      ++fracDigits;
+    }
+  }
+
+  constexpr std::uint64_t kPositiveLimit =
+      static_cast<std::uint64_t>(std::numeric_limits<std::int64_t>::max());
+  constexpr std::uint64_t kNegativeLimit = kPositiveLimit + 1ULL;
+  const std::uint64_t limit = negative ? kNegativeLimit : kPositiveLimit;
+  if (whole > limit / kNanosPerSecond) {
+    return false;
+  }
+  std::uint64_t scaled = whole * kNanosPerSecond;
+  if (scaled > limit - frac) {
+    return false;
+  }
+  scaled += frac;
+
+  if (negative) {
+    if (scaled == kNegativeLimit) {
+      out = std::numeric_limits<std::int64_t>::min();
+    } else {
+      out = -static_cast<std::int64_t>(scaled);
+    }
+  } else {
+    out = static_cast<std::int64_t>(scaled);
+  }
+  return true;
+}
+
+bool readPrice(simdjson::dom::element elem, std::int64_t &out) {
+  if (elem.is_null()) {
+    out = UNDEF_PRICE;
+    return true;
+  }
+  if (readI64(elem, out)) {
+    return true;
+  }
+  if (!elem.is_string()) {
+    return false;
+  }
+  const std::string_view s = elem.get_string().value();
+  if (s.find('.') != std::string_view::npos) {
+    return parseFixedPointPrice(s, out);
+  }
+  return parseIntFromString(s, out);
+}
+
+bool fieldTimestamp(simdjson::dom::object obj, std::string_view key,
+                    std::uint64_t &out) {
+  auto e = obj[key];
+  if (e.error() != simdjson::SUCCESS) {
+    return false;
+  }
+  return readTimestamp(e.value(), out);
+}
+
+bool fieldPrice(simdjson::dom::object obj, std::string_view key,
+                std::int64_t &out) {
+  auto e = obj[key];
+  if (e.error() != simdjson::SUCCESS) {
+    return false;
+  }
+  return readPrice(e.value(), out);
+}
+
+template <class UInt>
+bool fieldUnsignedOpt(simdjson::dom::object obj, std::string_view key,
+                      UInt &out) {
+  auto e = obj[key];
+  if (e.error() != simdjson::SUCCESS) {
+    return true;
+  }
+  std::uint64_t value = 0;
+  if (!readU64(e.value(), value)) {
+    return false;
+  }
+  return assignUnsigned(value, out);
+}
+
+bool isMboRtype(simdjson::dom::element elem) {
+  std::uint64_t n = 0;
+  if (readU64(elem, n)) {
+    return n == RTYPE_MBO;
+  }
+  if (elem.is_string()) {
+    std::string_view s = elem.get_string().value();
+    return s == "mbo";
+  }
+  return false;
+}
+
+char readCharCode(simdjson::dom::object obj, std::string_view key,
+                  char fallback) {
+  auto e = obj[key];
+  if (e.error() != simdjson::SUCCESS) {
+    return fallback;
+  }
+  if (!e.value().is_string()) {
+    return fallback;
+  }
+  std::string_view s = e.value().get_string().value();
+  return s.empty() ? fallback : s.front();
+}
+
+MdAction toAction(char c) {
+  switch (c) {
+  case 'A':
+    return MdAction::Add;
+  case 'M':
+    return MdAction::Modify;
+  case 'C':
+    return MdAction::Cancel;
+  case 'R':
+    return MdAction::Clear;
+  case 'T':
+    return MdAction::Trade;
+  case 'F':
+    return MdAction::Fill;
+  default:
+    return MdAction::None;
+  }
+}
+
+MdSide toSide(char c) {
+  switch (c) {
+  case 'A':
+    return MdSide::Ask;
+  case 'B':
+    return MdSide::Bid;
+  default:
+    return MdSide::None;
+  }
+}
+
+} // namespace
+
+struct MboDecoder::Impl {
+  simdjson::dom::parser parser;
+};
+
+MboDecoder::MboDecoder() : impl_{std::make_unique<Impl>()} {}
+MboDecoder::~MboDecoder() = default;
+MboDecoder::MboDecoder(MboDecoder &&) noexcept = default;
+MboDecoder &MboDecoder::operator=(MboDecoder &&) noexcept = default;
+
+DecodeResult MboDecoder::decodeLine(std::string_view line) {
+  DecodeResult result{DecodeOutcome::ParseError, {}};
+
+  auto docResult = impl_->parser.parse(line.data(), line.size());
+  if (docResult.error() != simdjson::SUCCESS) {
+    return result;
+  }
+  auto objResult = docResult.get_object();
+  if (objResult.error() != simdjson::SUCCESS) {
+    return result;
+  }
+  simdjson::dom::object obj = objResult.value();
+
+  simdjson::dom::object header = obj;
+  if (auto hd = obj["hd"]; hd.error() == simdjson::SUCCESS) {
+    auto hdObj = hd.value().get_object();
+    if (hdObj.error() != simdjson::SUCCESS) {
+      return result;
+    }
+    header = hdObj.value();
+  }
+
+  auto rtypeElem = header["rtype"];
+  if (rtypeElem.error() != simdjson::SUCCESS ||
+      !isMboRtype(rtypeElem.value())) {
+    result.outcome = DecodeOutcome::SkippedRtype;
+    return result;
+  }
+
+  MarketDataEvent e{};
+
+  // Required fields; any missing ⇒ parse error.
+  if (!fieldTimestamp(obj, "ts_recv", e.ts_recv)) {
+    return result;
+  }
+  if (!fieldTimestamp(header, "ts_event", e.ts_event)) {
+    return result;
+  }
+  if (!fieldPrice(obj, "price", e.price)) {
+    return result;
+  }
+
+  if (!fieldUnsignedOpt(obj, "order_id", e.order_id) ||
+      !fieldUnsignedOpt(obj, "size", e.size) ||
+      !fieldUnsignedOpt(obj, "sequence", e.sequence) ||
+      !fieldUnsignedOpt(header, "instrument_id", e.instrument_id) ||
+      !fieldUnsignedOpt(header, "publisher_id", e.publisher_id) ||
+      !fieldUnsignedOpt(obj, "flags", e.flags) ||
+      !fieldUnsignedOpt(obj, "channel_id", e.channel_id)) {
+    return result;
+  }
+
+  std::int64_t delta = 0;
+  if (auto d = obj["ts_in_delta"]; d.error() == simdjson::SUCCESS) {
+    if (!readI64(d.value(), delta)) {
+      return result;
+    }
+    if (!assignSigned(delta, e.ts_in_delta)) {
+      return result;
+    }
+  }
+
+  e.action = toAction(readCharCode(obj, "action", 'N'));
+  e.side = toSide(readCharCode(obj, "side", 'N'));
+
+  result.outcome = DecodeOutcome::Ok;
+  result.event = e;
+  return result;
+}
+
+} // namespace cmf

--- a/src/ingest/MboDecoder.hpp
+++ b/src/ingest/MboDecoder.hpp
@@ -1,0 +1,46 @@
+// Per-line JSON → MarketDataEvent decoder for Databento MBO records.
+//
+// Opaque handle hides simdjson from public headers; one decoder holds a
+// long-lived parser so per-line parses reuse its buffers.
+
+#pragma once
+
+#include "common/MarketDataEvent.hpp"
+
+#include <memory>
+#include <optional>
+#include <string_view>
+
+namespace cmf {
+
+// Why the decoder reports: we need to distinguish "valid JSON but not MBO"
+// (skipped_rtype) from "parse failure" (skipped_parse) so the summary matches
+// the spec's wording of "every valid message".
+enum class DecodeOutcome {
+  Ok,
+  SkippedRtype,
+  ParseError,
+};
+
+struct DecodeResult {
+  DecodeOutcome outcome;
+  MarketDataEvent event; // only meaningful when outcome == Ok
+};
+
+class MboDecoder {
+public:
+  MboDecoder();
+  ~MboDecoder();
+  MboDecoder(const MboDecoder &) = delete;
+  MboDecoder &operator=(const MboDecoder &) = delete;
+  MboDecoder(MboDecoder &&) noexcept;
+  MboDecoder &operator=(MboDecoder &&) noexcept;
+
+  DecodeResult decodeLine(std::string_view line);
+
+private:
+  struct Impl;
+  std::unique_ptr<Impl> impl_;
+};
+
+} // namespace cmf

--- a/src/ingest/NdjsonReader.cpp
+++ b/src/ingest/NdjsonReader.cpp
@@ -1,0 +1,53 @@
+#include "ingest/NdjsonReader.hpp"
+
+#include "ingest/MboDecoder.hpp"
+
+#include <fstream>
+#include <stdexcept>
+#include <string>
+
+namespace cmf {
+
+IngestStats parseNdjsonFile(const std::filesystem::path &path,
+                            const MarketDataEventConsumer &consumer) {
+  std::ifstream fs(path);
+  if (!fs) {
+    throw std::runtime_error("parseNdjsonFile: cannot open " + path.string());
+  }
+
+  IngestStats stats{};
+  MboDecoder decoder;
+  std::string line;
+  line.reserve(4096);
+
+  while (std::getline(fs, line)) {
+    if (line.empty()) {
+      continue;
+    }
+    const auto result = decoder.decodeLine(line);
+    switch (result.outcome) {
+    case DecodeOutcome::Ok: {
+      const auto &e = result.event;
+      if (stats.consumed == 0) {
+        stats.first_ts_recv = e.ts_recv;
+      } else if (e.ts_recv < stats.last_ts_recv) {
+        ++stats.out_of_order_ts_recv;
+      }
+      stats.last_ts_recv = e.ts_recv;
+      ++stats.consumed;
+      consumer(e);
+      break;
+    }
+    case DecodeOutcome::SkippedRtype:
+      ++stats.skipped_rtype;
+      break;
+    case DecodeOutcome::ParseError:
+      ++stats.skipped_parse;
+      break;
+    }
+  }
+
+  return stats;
+}
+
+} // namespace cmf

--- a/src/ingest/NdjsonReader.cpp
+++ b/src/ingest/NdjsonReader.cpp
@@ -9,7 +9,7 @@
 namespace cmf {
 
 IngestStats parseNdjsonFile(const std::filesystem::path &path,
-                            const MarketDataEventConsumer &consumer) {
+                            const MarketDataEventVisitor &visitor) {
   std::ifstream fs(path);
   if (!fs) {
     throw std::runtime_error("parseNdjsonFile: cannot open " + path.string());
@@ -35,7 +35,9 @@ IngestStats parseNdjsonFile(const std::filesystem::path &path,
       }
       stats.last_ts_recv = e.ts_recv;
       ++stats.consumed;
-      consumer(e);
+      if (!visitor(e)) {
+        return stats;
+      }
       break;
     }
     case DecodeOutcome::SkippedRtype:
@@ -48,6 +50,15 @@ IngestStats parseNdjsonFile(const std::filesystem::path &path,
   }
 
   return stats;
+}
+
+IngestStats parseNdjsonFile(const std::filesystem::path &path,
+                            const MarketDataEventConsumer &consumer) {
+  return parseNdjsonFile(
+      path, MarketDataEventVisitor{[&](const MarketDataEvent &event) {
+        consumer(event);
+        return true;
+      }});
 }
 
 } // namespace cmf

--- a/src/ingest/NdjsonReader.hpp
+++ b/src/ingest/NdjsonReader.hpp
@@ -1,0 +1,32 @@
+// NDJSON → MarketDataEvent reader.
+//
+// parseNdjsonFile is stateless and reentrant: each call owns its ifstream,
+// JSON parser, and local stats. Safe to run N concurrent instances on N
+// different files, as the hard variant will require.
+
+#pragma once
+
+#include "common/MarketDataEvent.hpp"
+
+#include <cstddef>
+#include <cstdint>
+#include <filesystem>
+#include <functional>
+
+namespace cmf {
+
+struct IngestStats {
+  std::size_t consumed = 0;
+  std::size_t skipped_rtype = 0;
+  std::size_t skipped_parse = 0;
+  std::size_t out_of_order_ts_recv = 0;
+  std::uint64_t first_ts_recv = UNDEF_TIMESTAMP;
+  std::uint64_t last_ts_recv = UNDEF_TIMESTAMP;
+};
+
+using MarketDataEventConsumer = std::function<void(const MarketDataEvent &)>;
+
+IngestStats parseNdjsonFile(const std::filesystem::path &path,
+                            const MarketDataEventConsumer &consumer);
+
+} // namespace cmf

--- a/src/ingest/NdjsonReader.hpp
+++ b/src/ingest/NdjsonReader.hpp
@@ -25,6 +25,10 @@ struct IngestStats {
 };
 
 using MarketDataEventConsumer = std::function<void(const MarketDataEvent &)>;
+using MarketDataEventVisitor = std::function<bool(const MarketDataEvent &)>;
+
+IngestStats parseNdjsonFile(const std::filesystem::path &path,
+                            const MarketDataEventVisitor &visitor);
 
 IngestStats parseNdjsonFile(const std::filesystem::path &path,
                             const MarketDataEventConsumer &consumer);

--- a/src/lob/BookDispatcher.cpp
+++ b/src/lob/BookDispatcher.cpp
@@ -1,0 +1,146 @@
+#include "lob/BookDispatcher.hpp"
+
+#include <algorithm>
+
+namespace cmf {
+
+BookDispatcher::BookDispatcher(DispatchOptions options) : options_(options) {}
+
+void BookDispatcher::apply(const MarketDataEvent &event) {
+  ++stats_.total_events;
+  switch (event.action) {
+  case MdAction::Add:
+    ++stats_.adds;
+    break;
+  case MdAction::Cancel:
+    ++stats_.cancels;
+    break;
+  case MdAction::Modify:
+    ++stats_.modifies;
+    break;
+  case MdAction::Clear:
+    ++stats_.clears;
+    break;
+  case MdAction::Trade:
+    ++stats_.trades;
+    break;
+  case MdAction::Fill:
+    ++stats_.fills;
+    break;
+  case MdAction::None:
+    ++stats_.none;
+    break;
+  }
+
+  bool ambiguous = false;
+  const auto instrument_id = resolveInstrumentId(event, ambiguous);
+  if (!instrument_id.has_value()) {
+    if (ambiguous) {
+      ++stats_.ambiguous_routes;
+    } else {
+      ++stats_.unresolved_routes;
+    }
+    return;
+  }
+
+  LimitOrderBook &book = getOrCreateBook(*instrument_id);
+  const ApplyResult result = book.apply(event);
+  if (result.missing_order) {
+    ++stats_.missing_order_events;
+  }
+  if (result.ignored) {
+    ++stats_.ignored_events;
+  }
+  maybeCaptureSnapshot(book, event);
+}
+
+std::vector<BookSummary> BookDispatcher::finalSummaries(std::size_t depth) const {
+  std::vector<BookSummary> summaries;
+  summaries.reserve(books_.size());
+  for (const auto &[instrument_id, book] : books_) {
+    (void)instrument_id;
+    summaries.push_back(summarise(book, depth));
+  }
+  std::sort(summaries.begin(), summaries.end(),
+            [](const BookSummary &lhs, const BookSummary &rhs) {
+              const bool lhs_active =
+                  lhs.best_bid.has_value() || lhs.best_ask.has_value();
+              const bool rhs_active =
+                  rhs.best_bid.has_value() || rhs.best_ask.has_value();
+              if (lhs_active != rhs_active) {
+                return lhs_active > rhs_active;
+              }
+              if (lhs.orders != rhs.orders) {
+                return lhs.orders > rhs.orders;
+              }
+              return lhs.instrument_id < rhs.instrument_id;
+            });
+  return summaries;
+}
+
+LimitOrderBook &BookDispatcher::getOrCreateBook(std::uint32_t instrument_id) {
+  const auto [it, inserted] = books_.try_emplace(instrument_id, instrument_id);
+  if (inserted) {
+    stats_.instruments = books_.size();
+  }
+  return it->second;
+}
+
+std::optional<std::uint32_t>
+BookDispatcher::resolveInstrumentId(const MarketDataEvent &event,
+                                    bool &ambiguous) const {
+  if (event.instrument_id != 0) {
+    return event.instrument_id;
+  }
+  if (event.order_id == 0) {
+    return std::nullopt;
+  }
+
+  std::optional<std::uint32_t> resolved;
+  for (const auto &[instrument_id, book] : books_) {
+    if (!book.hasOrder(event.publisher_id, event.order_id)) {
+      continue;
+    }
+    if (resolved.has_value()) {
+      ambiguous = true;
+      return std::nullopt;
+    }
+    resolved = instrument_id;
+  }
+  return resolved;
+}
+
+BookSummary BookDispatcher::summarise(const LimitOrderBook &book,
+                                      std::size_t depth) const {
+  return BookSummary{
+      .instrument_id = book.instrumentId(),
+      .orders = book.orderCount(),
+      .bid_levels = book.bidLevelCount(),
+      .ask_levels = book.askLevelCount(),
+      .best_bid = book.bestBid(),
+      .best_ask = book.bestAsk(),
+      .snapshot = book.snapshotString(depth),
+  };
+}
+
+void BookDispatcher::maybeCaptureSnapshot(const LimitOrderBook &book,
+                                          const MarketDataEvent &event) {
+  if (snapshots_.size() >= options_.max_snapshots) {
+    return;
+  }
+  const bool is_first = stats_.total_events == 1;
+  const bool hits_interval =
+      options_.snapshot_every > 0 &&
+      stats_.total_events % options_.snapshot_every == 0;
+  if (!is_first && !hits_interval) {
+    return;
+  }
+  snapshots_.push_back(CapturedSnapshot{
+      .event_index = stats_.total_events,
+      .ts_recv = event.ts_recv,
+      .book = summarise(book, options_.snapshot_depth),
+  });
+  stats_.snapshots = snapshots_.size();
+}
+
+} // namespace cmf

--- a/src/lob/BookDispatcher.hpp
+++ b/src/lob/BookDispatcher.hpp
@@ -1,0 +1,83 @@
+// Sequential dispatcher that routes merged events into one LOB per instrument.
+
+#pragma once
+
+#include "lob/LimitOrderBook.hpp"
+
+#include <cstddef>
+#include <cstdint>
+#include <map>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace cmf {
+
+struct DispatchOptions {
+  std::size_t snapshot_every = 100'000;
+  std::size_t max_snapshots = 3;
+  std::size_t snapshot_depth = 5;
+};
+
+struct DispatchStats {
+  std::size_t total_events = 0;
+  std::size_t instruments = 0;
+  std::size_t snapshots = 0;
+  std::size_t missing_order_events = 0;
+  std::size_t ignored_events = 0;
+  std::size_t unresolved_routes = 0;
+  std::size_t ambiguous_routes = 0;
+  std::size_t adds = 0;
+  std::size_t cancels = 0;
+  std::size_t modifies = 0;
+  std::size_t clears = 0;
+  std::size_t trades = 0;
+  std::size_t fills = 0;
+  std::size_t none = 0;
+};
+
+struct BookSummary {
+  std::uint32_t instrument_id{0};
+  std::size_t orders = 0;
+  std::size_t bid_levels = 0;
+  std::size_t ask_levels = 0;
+  std::optional<PriceLevel> best_bid;
+  std::optional<PriceLevel> best_ask;
+  std::string snapshot;
+};
+
+struct CapturedSnapshot {
+  std::size_t event_index = 0;
+  std::uint64_t ts_recv = UNDEF_TIMESTAMP;
+  BookSummary book;
+};
+
+class BookDispatcher {
+public:
+  explicit BookDispatcher(DispatchOptions options = {});
+
+  void apply(const MarketDataEvent &event);
+
+  [[nodiscard]] const DispatchStats &stats() const noexcept { return stats_; }
+  [[nodiscard]] const std::vector<CapturedSnapshot> &snapshots() const noexcept {
+    return snapshots_;
+  }
+  [[nodiscard]] std::vector<BookSummary>
+  finalSummaries(std::size_t depth = 1) const;
+
+private:
+  LimitOrderBook &getOrCreateBook(std::uint32_t instrument_id);
+  std::optional<std::uint32_t>
+  resolveInstrumentId(const MarketDataEvent &event, bool &ambiguous) const;
+  [[nodiscard]] BookSummary summarise(const LimitOrderBook &book,
+                                      std::size_t depth) const;
+  void maybeCaptureSnapshot(const LimitOrderBook &book,
+                            const MarketDataEvent &event);
+
+  DispatchOptions options_{};
+  DispatchStats stats_{};
+  std::map<std::uint32_t, LimitOrderBook> books_;
+  std::vector<CapturedSnapshot> snapshots_;
+};
+
+} // namespace cmf

--- a/src/lob/CMakeLists.txt
+++ b/src/lob/CMakeLists.txt
@@ -1,0 +1,7 @@
+set(TARGET back-tester-lob)
+file(GLOB SRC CONFIGURE_DEPENDS *.cpp)
+
+add_library(${TARGET} STATIC ${SRC})
+target_link_libraries(${TARGET} PUBLIC
+    back-tester-common
+)

--- a/src/lob/LimitOrderBook.cpp
+++ b/src/lob/LimitOrderBook.cpp
@@ -1,0 +1,246 @@
+#include "lob/LimitOrderBook.hpp"
+
+#include <algorithm>
+#include <iomanip>
+#include <sstream>
+
+namespace cmf {
+
+namespace {
+
+constexpr std::uint64_t kPriceScale = 1'000'000'000ULL;
+
+template <class Levels>
+void adjustLevel(Levels &levels, std::int64_t price, std::int64_t delta) {
+  if (price == UNDEF_PRICE || delta == 0) {
+    return;
+  }
+  auto it = levels.find(price);
+  if (delta > 0) {
+    if (it == levels.end()) {
+      levels.emplace(price, static_cast<std::uint64_t>(delta));
+    } else {
+      it->second += static_cast<std::uint64_t>(delta);
+    }
+    return;
+  }
+  if (it == levels.end()) {
+    return;
+  }
+  const auto removal = static_cast<std::uint64_t>(-delta);
+  if (removal >= it->second) {
+    levels.erase(it);
+    return;
+  }
+  it->second -= removal;
+}
+
+std::string formatPrice(std::int64_t price) {
+  if (price == UNDEF_PRICE) {
+    return "undef";
+  }
+  const bool negative = price < 0;
+  const auto magnitude = negative
+                             ? static_cast<std::uint64_t>(-(price + 1)) + 1ULL
+                             : static_cast<std::uint64_t>(price);
+  const auto whole = magnitude / kPriceScale;
+  const auto fractional = magnitude % kPriceScale;
+
+  std::ostringstream out;
+  if (negative) {
+    out << '-';
+  }
+  out << whole << '.' << std::setw(9) << std::setfill('0') << fractional;
+  return out.str();
+}
+
+template <class Levels>
+std::string formatLevels(const Levels &levels, std::size_t depth) {
+  std::ostringstream out;
+  out << '[';
+  std::size_t index = 0;
+  for (const auto &[price, size] : levels) {
+    if (index == depth) {
+      break;
+    }
+    if (index != 0) {
+      out << ", ";
+    }
+    out << formatPrice(price) << 'x' << size;
+    ++index;
+  }
+  out << ']';
+  return out.str();
+}
+
+std::string formatTop(const std::optional<PriceLevel> &level) {
+  if (!level.has_value()) {
+    return "none";
+  }
+  return formatPrice(level->price) + 'x' + std::to_string(level->size);
+}
+
+} // namespace
+
+LimitOrderBook::LimitOrderBook(std::uint32_t instrument_id)
+    : instrument_id_(instrument_id) {}
+
+ApplyResult LimitOrderBook::apply(const MarketDataEvent &event) {
+  switch (event.action) {
+  case MdAction::Add:
+    return applyAdd(event);
+  case MdAction::Cancel:
+    return applyCancel(event);
+  case MdAction::Modify:
+    return applyModify(event);
+  case MdAction::Clear:
+    bids_.clear();
+    asks_.clear();
+    orders_.clear();
+    return {};
+  case MdAction::Trade:
+  case MdAction::Fill:
+  case MdAction::None:
+    return {};
+  }
+  return {};
+}
+
+std::optional<PriceLevel> LimitOrderBook::bestBid() const noexcept {
+  if (bids_.empty()) {
+    return std::nullopt;
+  }
+  const auto &[price, size] = *bids_.begin();
+  return PriceLevel{price, size};
+}
+
+std::optional<PriceLevel> LimitOrderBook::bestAsk() const noexcept {
+  if (asks_.empty()) {
+    return std::nullopt;
+  }
+  const auto &[price, size] = *asks_.begin();
+  return PriceLevel{price, size};
+}
+
+std::uint64_t LimitOrderBook::volumeAtPrice(MdSide side,
+                                            std::int64_t price) const noexcept {
+  if (side == MdSide::Bid) {
+    const auto it = bids_.find(price);
+    return it == bids_.end() ? 0 : it->second;
+  }
+  if (side == MdSide::Ask) {
+    const auto it = asks_.find(price);
+    return it == asks_.end() ? 0 : it->second;
+  }
+  return 0;
+}
+
+bool LimitOrderBook::hasOrder(std::uint16_t publisher_id,
+                              std::uint64_t order_id) const noexcept {
+  return orders_.contains(OrderKey{publisher_id, order_id});
+}
+
+std::string LimitOrderBook::snapshotString(std::size_t depth) const {
+  std::ostringstream out;
+  out << "instrument=" << instrument_id_ << " orders=" << orderCount()
+      << " bid_levels=" << bidLevelCount() << " ask_levels=" << askLevelCount()
+      << " best_bid=" << formatTop(bestBid())
+      << " best_ask=" << formatTop(bestAsk()) << " bids="
+      << formatLevels(bids_, depth) << " asks=" << formatLevels(asks_, depth);
+  return out.str();
+}
+
+std::size_t
+LimitOrderBook::OrderKeyHash::operator()(const OrderKey &key) const noexcept {
+  const std::size_t lhs = std::hash<std::uint16_t>{}(key.publisher_id);
+  const std::size_t rhs = std::hash<std::uint64_t>{}(key.order_id);
+  return lhs ^ (rhs + 0x9e3779b97f4a7c15ULL + (lhs << 6U) + (lhs >> 2U));
+}
+
+ApplyResult LimitOrderBook::applyAdd(const MarketDataEvent &event) {
+  if (!isRestingOrder(event.side, event.price, event.size)) {
+    return {.ignored = true};
+  }
+
+  const OrderKey key = makeOrderKey(event);
+  const auto existing = orders_.find(key);
+  if (existing != orders_.end()) {
+    eraseOrder(existing->first, existing->second);
+  }
+  addOrder(key, OrderState{event.price, event.size, event.side});
+  return {};
+}
+
+ApplyResult LimitOrderBook::applyCancel(const MarketDataEvent &event) {
+  const OrderKey key = makeOrderKey(event);
+  const auto it = orders_.find(key);
+  if (it == orders_.end()) {
+    return {.missing_order = true};
+  }
+
+  OrderState updated = it->second;
+  const std::uint32_t cancel_size =
+      event.size == 0 ? updated.size : std::min(event.size, updated.size);
+  eraseOrder(it->first, it->second);
+
+  if (cancel_size < updated.size) {
+    updated.size -= cancel_size;
+    addOrder(key, updated);
+  }
+  return {};
+}
+
+ApplyResult LimitOrderBook::applyModify(const MarketDataEvent &event) {
+  const OrderKey key = makeOrderKey(event);
+  const auto it = orders_.find(key);
+  if (it == orders_.end()) {
+    return {.missing_order = true};
+  }
+
+  OrderState updated = it->second;
+  if (event.side != MdSide::None) {
+    updated.side = event.side;
+  }
+  if (event.price != UNDEF_PRICE) {
+    updated.price = event.price;
+  }
+  updated.size = event.size;
+
+  eraseOrder(it->first, it->second);
+  if (!isRestingOrder(updated.side, updated.price, updated.size)) {
+    return {};
+  }
+  addOrder(key, updated);
+  return {};
+}
+
+void LimitOrderBook::addOrder(const OrderKey &key, const OrderState &state) {
+  orders_[key] = state;
+  if (state.side == MdSide::Bid) {
+    adjustLevel(bids_, state.price, static_cast<std::int64_t>(state.size));
+  } else if (state.side == MdSide::Ask) {
+    adjustLevel(asks_, state.price, static_cast<std::int64_t>(state.size));
+  }
+}
+
+void LimitOrderBook::eraseOrder(const OrderKey &key, const OrderState &state) {
+  if (state.side == MdSide::Bid) {
+    adjustLevel(bids_, state.price, -static_cast<std::int64_t>(state.size));
+  } else if (state.side == MdSide::Ask) {
+    adjustLevel(asks_, state.price, -static_cast<std::int64_t>(state.size));
+  }
+  orders_.erase(key);
+}
+
+bool LimitOrderBook::isRestingOrder(MdSide side, std::int64_t price,
+                                    std::uint32_t size) noexcept {
+  return (side == MdSide::Bid || side == MdSide::Ask) && price != UNDEF_PRICE &&
+         size > 0;
+}
+
+LimitOrderBook::OrderKey
+LimitOrderBook::makeOrderKey(const MarketDataEvent &event) noexcept {
+  return OrderKey{event.publisher_id, event.order_id};
+}
+
+} // namespace cmf

--- a/src/lob/LimitOrderBook.hpp
+++ b/src/lob/LimitOrderBook.hpp
@@ -1,0 +1,80 @@
+// Per-instrument L2 order book rebuilt from Databento MBO events.
+
+#pragma once
+
+#include "common/MarketDataEvent.hpp"
+
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <map>
+#include <optional>
+#include <string>
+#include <unordered_map>
+
+namespace cmf {
+
+struct PriceLevel {
+  std::int64_t price{UNDEF_PRICE};
+  std::uint64_t size{0};
+};
+
+struct ApplyResult {
+  bool missing_order = false;
+  bool ignored = false;
+};
+
+class LimitOrderBook {
+public:
+  explicit LimitOrderBook(std::uint32_t instrument_id);
+
+  ApplyResult apply(const MarketDataEvent &event);
+
+  [[nodiscard]] std::optional<PriceLevel> bestBid() const noexcept;
+  [[nodiscard]] std::optional<PriceLevel> bestAsk() const noexcept;
+  [[nodiscard]] std::uint64_t volumeAtPrice(MdSide side,
+                                            std::int64_t price) const noexcept;
+  [[nodiscard]] std::size_t orderCount() const noexcept { return orders_.size(); }
+  [[nodiscard]] std::size_t bidLevelCount() const noexcept { return bids_.size(); }
+  [[nodiscard]] std::size_t askLevelCount() const noexcept { return asks_.size(); }
+  [[nodiscard]] bool hasOrder(std::uint16_t publisher_id,
+                              std::uint64_t order_id) const noexcept;
+  [[nodiscard]] std::uint32_t instrumentId() const noexcept {
+    return instrument_id_;
+  }
+  [[nodiscard]] std::string snapshotString(std::size_t depth = 5) const;
+
+private:
+  struct OrderKey {
+    std::uint16_t publisher_id{0};
+    std::uint64_t order_id{0};
+
+    bool operator==(const OrderKey &) const = default;
+  };
+
+  struct OrderKeyHash {
+    std::size_t operator()(const OrderKey &key) const noexcept;
+  };
+
+  struct OrderState {
+    std::int64_t price{UNDEF_PRICE};
+    std::uint32_t size{0};
+    MdSide side{MdSide::None};
+  };
+
+  ApplyResult applyAdd(const MarketDataEvent &event);
+  ApplyResult applyCancel(const MarketDataEvent &event);
+  ApplyResult applyModify(const MarketDataEvent &event);
+  void addOrder(const OrderKey &key, const OrderState &state);
+  void eraseOrder(const OrderKey &key, const OrderState &state);
+  static bool isRestingOrder(MdSide side, std::int64_t price,
+                             std::uint32_t size) noexcept;
+  static OrderKey makeOrderKey(const MarketDataEvent &event) noexcept;
+
+  std::uint32_t instrument_id_{0};
+  std::map<std::int64_t, std::uint64_t, std::greater<>> bids_;
+  std::map<std::int64_t, std::uint64_t> asks_;
+  std::unordered_map<OrderKey, OrderState, OrderKeyHash> orders_;
+};
+
+} // namespace cmf

--- a/src/main/CMakeLists.txt
+++ b/src/main/CMakeLists.txt
@@ -11,4 +11,4 @@ target_link_libraries(${TARGET} PUBLIC
 # executable
 set(TARGET back-tester)
 add_executable(${TARGET} main.cpp)
-target_link_libraries(${TARGET} PUBLIC back-tester-lib)
+target_link_libraries(${TARGET} PUBLIC back-tester-lib back-tester-ingest)

--- a/src/main/CMakeLists.txt
+++ b/src/main/CMakeLists.txt
@@ -11,4 +11,8 @@ target_link_libraries(${TARGET} PUBLIC
 # executable
 set(TARGET back-tester)
 add_executable(${TARGET} main.cpp)
-target_link_libraries(${TARGET} PUBLIC back-tester-lib back-tester-ingest)
+target_link_libraries(${TARGET} PUBLIC
+    back-tester-lib
+    back-tester-ingest
+    back-tester-lob
+)

--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -179,6 +179,8 @@ void printFolderSummary(const FolderIngestStats &stats) {
             << " first_ts_recv=" << stats.first_ts_recv
             << " last_ts_recv=" << stats.last_ts_recv
             << " out_of_order_ts_recv=" << stats.out_of_order_ts_recv
+            << " producer_out_of_order_ts_recv="
+            << stats.producer_out_of_order_ts_recv
             << " elapsed_sec=" << stats.elapsed_sec
             << " msgs_per_sec=" << stats.msgsPerSec() << '\n';
 }

--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -5,6 +5,7 @@
 #include "ingest/FolderIngest.hpp"
 #include "ingest/NdjsonReader.hpp"
 
+#include <algorithm>
 #include <array>
 #include <charconv>
 #include <cstddef>

--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -1,23 +1,91 @@
 // main function for the back-tester app
 // please, keep it minimalistic
 
-#include "common/BasicTypes.hpp"
+#include "common/MarketDataEvent.hpp"
+#include "ingest/NdjsonReader.hpp"
 
+#include <array>
+#include <cstddef>
+#include <exception>
+#include <filesystem>
 #include <iostream>
+#include <vector>
 
 using namespace cmf;
 
-int main([[maybe_unused]] int argc, [[maybe_unused]] const char *argv[])
-{
-    try
-    {
-        std::cout << "Hell! Oh, world!" << std::endl;
+namespace {
+
+constexpr std::size_t kHeadPreviewSize = 10;
+constexpr std::size_t kTailPreviewSize = 10;
+
+struct PreviewState {
+  std::vector<MarketDataEvent> head;
+  std::array<MarketDataEvent, kTailPreviewSize> tail{};
+  std::size_t tailCount = 0;
+  std::size_t tailStart = 0;
+};
+
+PreviewState gPreview;
+
+} // namespace
+
+namespace cmf {
+
+// Spec-named consumer seam. Called for every decoded event; prints the first
+// kHeadPreviewSize events directly, and keeps the latest kTailPreviewSize in a
+// ring buffer for main() to flush after the stream ends.
+void processMarketDataEvent(const MarketDataEvent &event) {
+  if (gPreview.head.size() < kHeadPreviewSize) {
+    gPreview.head.push_back(event);
+    std::cout << event << '\n';
+  }
+
+  if (gPreview.tailCount < kTailPreviewSize) {
+    gPreview.tail[gPreview.tailCount] = event;
+    ++gPreview.tailCount;
+  } else {
+    gPreview.tail[gPreview.tailStart] = event;
+    gPreview.tailStart = (gPreview.tailStart + 1) % kTailPreviewSize;
+  }
+}
+
+} // namespace cmf
+
+int main(int argc, const char *argv[]) {
+  try {
+    if (argc != 2) {
+      std::cerr << "usage: back-tester <path-to-ndjson>\n";
+      return 2;
     }
-    catch (std::exception &ex)
-    {
-        std::cerr << "Back-tester threw an exception: " << ex.what() << std::endl;
-        return 1;
+    const std::filesystem::path path{argv[1]};
+
+    const IngestStats stats = parseNdjsonFile(path, &processMarketDataEvent);
+
+    const std::size_t tailToPrint =
+        stats.consumed > kHeadPreviewSize
+            ? std::min(kTailPreviewSize, stats.consumed - kHeadPreviewSize)
+            : 0;
+    if (tailToPrint > 0) {
+      std::cout << "\n--- tail ---\n";
+      const std::size_t tailSkip = gPreview.tailCount - tailToPrint;
+      for (std::size_t i = 0; i < tailToPrint; ++i) {
+        const std::size_t idx =
+            (gPreview.tailStart + tailSkip + i) % kTailPreviewSize;
+        std::cout << gPreview.tail[idx] << '\n';
+      }
     }
 
-    return 0;
+    std::cout << "\n"
+              << "total=" << stats.consumed
+              << " skipped_rtype=" << stats.skipped_rtype
+              << " skipped_parse=" << stats.skipped_parse
+              << " first_ts_recv=" << stats.first_ts_recv
+              << " last_ts_recv=" << stats.last_ts_recv
+              << " out_of_order_ts_recv=" << stats.out_of_order_ts_recv << '\n';
+  } catch (std::exception &ex) {
+    std::cerr << "Back-tester threw an exception: " << ex.what() << std::endl;
+    return 1;
+  }
+
+  return 0;
 }

--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -2,50 +2,208 @@
 // please, keep it minimalistic
 
 #include "common/MarketDataEvent.hpp"
+#include "ingest/FolderIngest.hpp"
 #include "ingest/NdjsonReader.hpp"
 
 #include <array>
+#include <charconv>
 #include <cstddef>
 #include <exception>
 #include <filesystem>
 #include <iostream>
+#include <string_view>
 #include <vector>
 
 using namespace cmf;
 
+namespace cmf {
+void processMarketDataEvent(const MarketDataEvent &event);
+}
+
 namespace {
 
-constexpr std::size_t kHeadPreviewSize = 10;
-constexpr std::size_t kTailPreviewSize = 10;
+constexpr std::size_t kDefaultPreviewSize = 10;
 
-struct PreviewState {
-  std::vector<MarketDataEvent> head;
-  std::array<MarketDataEvent, kTailPreviewSize> tail{};
-  std::size_t tailCount = 0;
-  std::size_t tailStart = 0;
+enum class StrategySelection {
+  Default,
+  Flat,
+  Hierarchy,
+  Both,
 };
 
-PreviewState gPreview;
+struct CliOptions {
+  std::filesystem::path input_path;
+  StrategySelection strategy = StrategySelection::Default;
+  std::size_t preview_limit = kDefaultPreviewSize;
+};
+
+struct PreviewState {
+  explicit PreviewState(std::size_t preview_limit)
+      : preview_limit(preview_limit),
+        tail(preview_limit == 0 ? 1 : preview_limit) {}
+
+  std::size_t preview_limit = 0;
+  std::vector<MarketDataEvent> head;
+  std::vector<MarketDataEvent> tail;
+  std::size_t tailCount = 0;
+  std::size_t tailStart = 0;
+  std::size_t consumed = 0;
+
+  void consume(const MarketDataEvent &event) {
+    ++consumed;
+    if (preview_limit == 0) {
+      return;
+    }
+    if (head.size() < preview_limit) {
+      head.push_back(event);
+      std::cout << event << '\n';
+    }
+
+    if (tailCount < preview_limit) {
+      tail[tailCount] = event;
+      ++tailCount;
+    } else {
+      tail[tailStart] = event;
+      tailStart = (tailStart + 1) % preview_limit;
+    }
+  }
+
+  void printTail() const {
+    if (preview_limit == 0) {
+      return;
+    }
+    const std::size_t tailToPrint =
+        consumed > preview_limit
+            ? std::min(preview_limit, consumed - preview_limit)
+            : 0;
+    if (tailToPrint == 0) {
+      return;
+    }
+    std::cout << "\n--- tail ---\n";
+    const std::size_t tailSkip = tailCount - tailToPrint;
+    for (std::size_t i = 0; i < tailToPrint; ++i) {
+      const std::size_t idx = (tailStart + tailSkip + i) % preview_limit;
+      std::cout << tail[idx] << '\n';
+    }
+  }
+};
+
+PreviewState *gPreview = nullptr;
+
+[[noreturn]] void usageError(std::string_view message) {
+  throw std::runtime_error(
+      std::string(message) +
+      "\nusage: back-tester <path> [--strategy flat|hierarchy|both] "
+      "[--preview-limit N]");
+}
+
+StrategySelection parseStrategySelection(std::string_view value) {
+  if (value == "flat") {
+    return StrategySelection::Flat;
+  }
+  if (value == "hierarchy") {
+    return StrategySelection::Hierarchy;
+  }
+  if (value == "both") {
+    return StrategySelection::Both;
+  }
+  usageError("invalid strategy");
+}
+
+std::size_t parsePreviewLimit(std::string_view value) {
+  std::size_t parsed = 0;
+  const char *first = value.data();
+  const char *last = first + value.size();
+  const auto [ptr, ec] = std::from_chars(first, last, parsed);
+  if (ec != std::errc() || ptr != last) {
+    usageError("invalid preview limit");
+  }
+  return parsed;
+}
+
+CliOptions parseCli(int argc, const char *argv[]) {
+  if (argc < 2) {
+    usageError("missing input path");
+  }
+
+  CliOptions options{};
+  options.input_path = argv[1];
+
+  for (int i = 2; i < argc; ++i) {
+    const std::string_view arg = argv[i];
+    if (arg == "--strategy") {
+      if (i + 1 >= argc) {
+        usageError("missing value for --strategy");
+      }
+      options.strategy = parseStrategySelection(argv[++i]);
+      continue;
+    }
+    if (arg == "--preview-limit") {
+      if (i + 1 >= argc) {
+        usageError("missing value for --preview-limit");
+      }
+      options.preview_limit = parsePreviewLimit(argv[++i]);
+      continue;
+    }
+    usageError("unknown argument");
+  }
+
+  return options;
+}
+
+void printSingleFileSummary(const IngestStats &stats) {
+  std::cout << "\n"
+            << "total=" << stats.consumed
+            << " skipped_rtype=" << stats.skipped_rtype
+            << " skipped_parse=" << stats.skipped_parse
+            << " first_ts_recv=" << stats.first_ts_recv
+            << " last_ts_recv=" << stats.last_ts_recv
+            << " out_of_order_ts_recv=" << stats.out_of_order_ts_recv << '\n';
+}
+
+void runSingleFile(const std::filesystem::path &path, std::size_t preview_limit) {
+  PreviewState preview(preview_limit);
+  gPreview = &preview;
+  const IngestStats stats = parseNdjsonFile(path, &processMarketDataEvent);
+  gPreview = nullptr;
+  preview.printTail();
+  printSingleFileSummary(stats);
+}
+
+void printFolderSummary(const FolderIngestStats &stats) {
+  std::cout << "\n"
+            << "strategy=" << mergeStrategyName(stats.strategy)
+            << " files=" << stats.files << " total=" << stats.total
+            << " skipped_rtype=" << stats.skipped_rtype
+            << " skipped_parse=" << stats.skipped_parse
+            << " first_ts_recv=" << stats.first_ts_recv
+            << " last_ts_recv=" << stats.last_ts_recv
+            << " out_of_order_ts_recv=" << stats.out_of_order_ts_recv
+            << " elapsed_sec=" << stats.elapsed_sec
+            << " msgs_per_sec=" << stats.msgsPerSec() << '\n';
+}
+
+void runFolderStrategy(const std::filesystem::path &path, MergeStrategy strategy,
+                       std::size_t preview_limit) {
+  std::cout << "--- strategy=" << mergeStrategyName(strategy) << " ---\n";
+  PreviewState preview(preview_limit);
+  gPreview = &preview;
+  const FolderIngestStats stats = ingestFolder(path, strategy, &processMarketDataEvent);
+  gPreview = nullptr;
+  preview.printTail();
+  printFolderSummary(stats);
+}
 
 } // namespace
 
 namespace cmf {
 
 // Spec-named consumer seam. Called for every decoded event; prints the first
-// kHeadPreviewSize events directly, and keeps the latest kTailPreviewSize in a
-// ring buffer for main() to flush after the stream ends.
+// preview-limit events directly, and keeps the latest preview-limit in a ring
+// buffer for main() to flush after the stream ends.
 void processMarketDataEvent(const MarketDataEvent &event) {
-  if (gPreview.head.size() < kHeadPreviewSize) {
-    gPreview.head.push_back(event);
-    std::cout << event << '\n';
-  }
-
-  if (gPreview.tailCount < kTailPreviewSize) {
-    gPreview.tail[gPreview.tailCount] = event;
-    ++gPreview.tailCount;
-  } else {
-    gPreview.tail[gPreview.tailStart] = event;
-    gPreview.tailStart = (gPreview.tailStart + 1) % kTailPreviewSize;
+  if (gPreview != nullptr) {
+    gPreview->consume(event);
   }
 }
 
@@ -53,35 +211,37 @@ void processMarketDataEvent(const MarketDataEvent &event) {
 
 int main(int argc, const char *argv[]) {
   try {
-    if (argc != 2) {
-      std::cerr << "usage: back-tester <path-to-ndjson>\n";
-      return 2;
-    }
-    const std::filesystem::path path{argv[1]};
-
-    const IngestStats stats = parseNdjsonFile(path, &processMarketDataEvent);
-
-    const std::size_t tailToPrint =
-        stats.consumed > kHeadPreviewSize
-            ? std::min(kTailPreviewSize, stats.consumed - kHeadPreviewSize)
-            : 0;
-    if (tailToPrint > 0) {
-      std::cout << "\n--- tail ---\n";
-      const std::size_t tailSkip = gPreview.tailCount - tailToPrint;
-      for (std::size_t i = 0; i < tailToPrint; ++i) {
-        const std::size_t idx =
-            (gPreview.tailStart + tailSkip + i) % kTailPreviewSize;
-        std::cout << gPreview.tail[idx] << '\n';
+    const CliOptions options = parseCli(argc, argv);
+    if (std::filesystem::is_directory(options.input_path)) {
+      const StrategySelection selection =
+          options.strategy == StrategySelection::Default
+              ? StrategySelection::Both
+              : options.strategy;
+      switch (selection) {
+      case StrategySelection::Flat:
+        runFolderStrategy(options.input_path, MergeStrategy::Flat,
+                          options.preview_limit);
+        break;
+      case StrategySelection::Hierarchy:
+        runFolderStrategy(options.input_path, MergeStrategy::Hierarchy,
+                          options.preview_limit);
+        break;
+      case StrategySelection::Both:
+        runFolderStrategy(options.input_path, MergeStrategy::Flat,
+                          options.preview_limit);
+        std::cout << '\n';
+        runFolderStrategy(options.input_path, MergeStrategy::Hierarchy,
+                          options.preview_limit);
+        break;
+      case StrategySelection::Default:
+        break;
       }
+    } else {
+      if (options.strategy != StrategySelection::Default) {
+        usageError("--strategy only valid for directory input");
+      }
+      runSingleFile(options.input_path, options.preview_limit);
     }
-
-    std::cout << "\n"
-              << "total=" << stats.consumed
-              << " skipped_rtype=" << stats.skipped_rtype
-              << " skipped_parse=" << stats.skipped_parse
-              << " first_ts_recv=" << stats.first_ts_recv
-              << " last_ts_recv=" << stats.last_ts_recv
-              << " out_of_order_ts_recv=" << stats.out_of_order_ts_recv << '\n';
   } catch (std::exception &ex) {
     std::cerr << "Back-tester threw an exception: " << ex.what() << std::endl;
     return 1;

--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -4,14 +4,17 @@
 #include "common/MarketDataEvent.hpp"
 #include "ingest/FolderIngest.hpp"
 #include "ingest/NdjsonReader.hpp"
+#include "lob/BookDispatcher.hpp"
 
 #include <algorithm>
-#include <array>
 #include <charconv>
+#include <chrono>
 #include <cstddef>
 #include <exception>
 #include <filesystem>
 #include <iostream>
+#include <stdexcept>
+#include <string>
 #include <string_view>
 #include <vector>
 
@@ -36,6 +39,10 @@ struct CliOptions {
   std::filesystem::path input_path;
   StrategySelection strategy = StrategySelection::Default;
   std::size_t preview_limit = kDefaultPreviewSize;
+  std::size_t snapshot_every = 100'000;
+  std::size_t snapshot_depth = 5;
+  std::size_t max_snapshots = 3;
+  std::size_t final_books_limit = 20;
 };
 
 struct PreviewState {
@@ -46,8 +53,8 @@ struct PreviewState {
   std::size_t preview_limit = 0;
   std::vector<MarketDataEvent> head;
   std::vector<MarketDataEvent> tail;
-  std::size_t tailCount = 0;
-  std::size_t tailStart = 0;
+  std::size_t tail_count = 0;
+  std::size_t tail_start = 0;
   std::size_t consumed = 0;
 
   void consume(const MarketDataEvent &event) {
@@ -60,12 +67,12 @@ struct PreviewState {
       std::cout << event << '\n';
     }
 
-    if (tailCount < preview_limit) {
-      tail[tailCount] = event;
-      ++tailCount;
+    if (tail_count < preview_limit) {
+      tail[tail_count] = event;
+      ++tail_count;
     } else {
-      tail[tailStart] = event;
-      tailStart = (tailStart + 1) % preview_limit;
+      tail[tail_start] = event;
+      tail_start = (tail_start + 1) % preview_limit;
     }
   }
 
@@ -73,29 +80,44 @@ struct PreviewState {
     if (preview_limit == 0) {
       return;
     }
-    const std::size_t tailToPrint =
+    const std::size_t tail_to_print =
         consumed > preview_limit
             ? std::min(preview_limit, consumed - preview_limit)
             : 0;
-    if (tailToPrint == 0) {
+    if (tail_to_print == 0) {
       return;
     }
     std::cout << "\n--- tail ---\n";
-    const std::size_t tailSkip = tailCount - tailToPrint;
-    for (std::size_t i = 0; i < tailToPrint; ++i) {
-      const std::size_t idx = (tailStart + tailSkip + i) % preview_limit;
+    const std::size_t tail_skip = tail_count - tail_to_print;
+    for (std::size_t i = 0; i < tail_to_print; ++i) {
+      const std::size_t idx = (tail_start + tail_skip + i) % preview_limit;
       std::cout << tail[idx] << '\n';
     }
   }
 };
 
-PreviewState *gPreview = nullptr;
+struct ReplayState {
+  PreviewState *preview = nullptr;
+  BookDispatcher *dispatcher = nullptr;
+
+  void consume(const MarketDataEvent &event) const {
+    if (preview != nullptr) {
+      preview->consume(event);
+    }
+    if (dispatcher != nullptr) {
+      dispatcher->apply(event);
+    }
+  }
+};
+
+ReplayState *gReplay = nullptr;
 
 [[noreturn]] void usageError(std::string_view message) {
   throw std::runtime_error(
       std::string(message) +
       "\nusage: back-tester <path> [--strategy flat|hierarchy|both] "
-      "[--preview-limit N]");
+      "[--preview-limit N] [--snapshot-every N] [--snapshot-depth N] "
+      "[--max-snapshots N] [--final-books-limit N]");
 }
 
 StrategySelection parseStrategySelection(std::string_view value) {
@@ -111,13 +133,13 @@ StrategySelection parseStrategySelection(std::string_view value) {
   usageError("invalid strategy");
 }
 
-std::size_t parsePreviewLimit(std::string_view value) {
+std::size_t parseCount(std::string_view value, std::string_view name) {
   std::size_t parsed = 0;
   const char *first = value.data();
   const char *last = first + value.size();
   const auto [ptr, ec] = std::from_chars(first, last, parsed);
   if (ec != std::errc() || ptr != last) {
-    usageError("invalid preview limit");
+    usageError(std::string("invalid ") + std::string(name));
   }
   return parsed;
 }
@@ -143,7 +165,35 @@ CliOptions parseCli(int argc, const char *argv[]) {
       if (i + 1 >= argc) {
         usageError("missing value for --preview-limit");
       }
-      options.preview_limit = parsePreviewLimit(argv[++i]);
+      options.preview_limit = parseCount(argv[++i], "preview limit");
+      continue;
+    }
+    if (arg == "--snapshot-every") {
+      if (i + 1 >= argc) {
+        usageError("missing value for --snapshot-every");
+      }
+      options.snapshot_every = parseCount(argv[++i], "snapshot interval");
+      continue;
+    }
+    if (arg == "--snapshot-depth") {
+      if (i + 1 >= argc) {
+        usageError("missing value for --snapshot-depth");
+      }
+      options.snapshot_depth = parseCount(argv[++i], "snapshot depth");
+      continue;
+    }
+    if (arg == "--max-snapshots") {
+      if (i + 1 >= argc) {
+        usageError("missing value for --max-snapshots");
+      }
+      options.max_snapshots = parseCount(argv[++i], "max snapshots");
+      continue;
+    }
+    if (arg == "--final-books-limit") {
+      if (i + 1 >= argc) {
+        usageError("missing value for --final-books-limit");
+      }
+      options.final_books_limit = parseCount(argv[++i], "final books limit");
       continue;
     }
     usageError("unknown argument");
@@ -152,26 +202,78 @@ CliOptions parseCli(int argc, const char *argv[]) {
   return options;
 }
 
-void printSingleFileSummary(const IngestStats &stats) {
+DispatchOptions toDispatchOptions(const CliOptions &options) {
+  return DispatchOptions{
+      .snapshot_every = options.snapshot_every,
+      .max_snapshots = options.max_snapshots,
+      .snapshot_depth = options.snapshot_depth,
+  };
+}
+
+void printBookSnapshots(const BookDispatcher &dispatcher) {
+  if (dispatcher.snapshots().empty()) {
+    return;
+  }
+  std::cout << "\n--- lob snapshots ---\n";
+  for (const auto &snapshot : dispatcher.snapshots()) {
+    std::cout << "event=" << snapshot.event_index
+              << " ts_recv=" << snapshot.ts_recv << ' '
+              << snapshot.book.snapshot << '\n';
+  }
+}
+
+void printFinalBooks(const BookDispatcher &dispatcher, std::size_t limit) {
+  const auto summaries = dispatcher.finalSummaries(1);
+  if (summaries.empty()) {
+    return;
+  }
+  const std::size_t to_print =
+      limit == 0 ? summaries.size() : std::min(limit, summaries.size());
+
+  std::cout << "\n--- final best bid/ask ---\n";
+  for (std::size_t i = 0; i < to_print; ++i) {
+    std::cout << summaries[i].snapshot << '\n';
+  }
+  if (to_print < summaries.size()) {
+    std::cout << "... truncated " << (summaries.size() - to_print)
+              << " instruments\n";
+  }
+}
+
+void printDispatcherSummary(const DispatchStats &stats) {
+  std::cout << " instruments=" << stats.instruments
+            << " snapshots=" << stats.snapshots
+            << " missing_order_events=" << stats.missing_order_events
+            << " ignored_events=" << stats.ignored_events
+            << " unresolved_routes=" << stats.unresolved_routes
+            << " ambiguous_routes=" << stats.ambiguous_routes
+            << " adds=" << stats.adds << " cancels=" << stats.cancels
+            << " modifies=" << stats.modifies << " clears=" << stats.clears
+            << " trades=" << stats.trades << " fills=" << stats.fills
+            << " none=" << stats.none;
+}
+
+void printSingleFileSummary(const IngestStats &stats,
+                            const DispatchStats &dispatch,
+                            double elapsed_sec) {
   std::cout << "\n"
             << "total=" << stats.consumed
             << " skipped_rtype=" << stats.skipped_rtype
             << " skipped_parse=" << stats.skipped_parse
             << " first_ts_recv=" << stats.first_ts_recv
             << " last_ts_recv=" << stats.last_ts_recv
-            << " out_of_order_ts_recv=" << stats.out_of_order_ts_recv << '\n';
+            << " out_of_order_ts_recv=" << stats.out_of_order_ts_recv
+            << " elapsed_sec=" << elapsed_sec
+            << " msgs_per_sec="
+            << (elapsed_sec > 0.0 ? static_cast<double>(stats.consumed) /
+                                        elapsed_sec
+                                  : 0.0);
+  printDispatcherSummary(dispatch);
+  std::cout << '\n';
 }
 
-void runSingleFile(const std::filesystem::path &path, std::size_t preview_limit) {
-  PreviewState preview(preview_limit);
-  gPreview = &preview;
-  const IngestStats stats = parseNdjsonFile(path, &processMarketDataEvent);
-  gPreview = nullptr;
-  preview.printTail();
-  printSingleFileSummary(stats);
-}
-
-void printFolderSummary(const FolderIngestStats &stats) {
+void printFolderSummary(const FolderIngestStats &stats,
+                        const DispatchStats &dispatch) {
   std::cout << "\n"
             << "strategy=" << mergeStrategyName(stats.strategy)
             << " files=" << stats.files << " total=" << stats.total
@@ -183,30 +285,57 @@ void printFolderSummary(const FolderIngestStats &stats) {
             << " producer_out_of_order_ts_recv="
             << stats.producer_out_of_order_ts_recv
             << " elapsed_sec=" << stats.elapsed_sec
-            << " msgs_per_sec=" << stats.msgsPerSec() << '\n';
+            << " msgs_per_sec=" << stats.msgsPerSec();
+  printDispatcherSummary(dispatch);
+  std::cout << '\n';
+}
+
+void runSingleFile(const std::filesystem::path &path, const CliOptions &options) {
+  PreviewState preview(options.preview_limit);
+  BookDispatcher dispatcher(toDispatchOptions(options));
+  ReplayState replay{.preview = &preview, .dispatcher = &dispatcher};
+  gReplay = &replay;
+
+  const auto started = std::chrono::steady_clock::now();
+  const IngestStats stats = parseNdjsonFile(path, &processMarketDataEvent);
+  const auto finished = std::chrono::steady_clock::now();
+  gReplay = nullptr;
+
+  const double elapsed_sec =
+      std::chrono::duration<double>(finished - started).count();
+  preview.printTail();
+  printBookSnapshots(dispatcher);
+  printFinalBooks(dispatcher, options.final_books_limit);
+  printSingleFileSummary(stats, dispatcher.stats(), elapsed_sec);
 }
 
 void runFolderStrategy(const std::filesystem::path &path, MergeStrategy strategy,
-                       std::size_t preview_limit) {
+                       const CliOptions &options) {
   std::cout << "--- strategy=" << mergeStrategyName(strategy) << " ---\n";
-  PreviewState preview(preview_limit);
-  gPreview = &preview;
-  const FolderIngestStats stats = ingestFolder(path, strategy, &processMarketDataEvent);
-  gPreview = nullptr;
+  PreviewState preview(options.preview_limit);
+  BookDispatcher dispatcher(toDispatchOptions(options));
+  ReplayState replay{.preview = &preview, .dispatcher = &dispatcher};
+  gReplay = &replay;
+
+  const FolderIngestStats stats =
+      ingestFolder(path, strategy, &processMarketDataEvent);
+  gReplay = nullptr;
+
   preview.printTail();
-  printFolderSummary(stats);
+  printBookSnapshots(dispatcher);
+  printFinalBooks(dispatcher, options.final_books_limit);
+  printFolderSummary(stats, dispatcher.stats());
 }
 
 } // namespace
 
 namespace cmf {
 
-// Spec-named consumer seam. Called for every decoded event; prints the first
-// preview-limit events directly, and keeps the latest preview-limit in a ring
-// buffer for main() to flush after the stream ends.
+// Spec-named consumer seam. Called for every decoded event; keeps the legacy
+// raw-event preview and now also drives the per-instrument LOB dispatcher.
 void processMarketDataEvent(const MarketDataEvent &event) {
-  if (gPreview != nullptr) {
-    gPreview->consume(event);
+  if (gReplay != nullptr) {
+    gReplay->consume(event);
   }
 }
 
@@ -222,19 +351,15 @@ int main(int argc, const char *argv[]) {
               : options.strategy;
       switch (selection) {
       case StrategySelection::Flat:
-        runFolderStrategy(options.input_path, MergeStrategy::Flat,
-                          options.preview_limit);
+        runFolderStrategy(options.input_path, MergeStrategy::Flat, options);
         break;
       case StrategySelection::Hierarchy:
-        runFolderStrategy(options.input_path, MergeStrategy::Hierarchy,
-                          options.preview_limit);
+        runFolderStrategy(options.input_path, MergeStrategy::Hierarchy, options);
         break;
       case StrategySelection::Both:
-        runFolderStrategy(options.input_path, MergeStrategy::Flat,
-                          options.preview_limit);
+        runFolderStrategy(options.input_path, MergeStrategy::Flat, options);
         std::cout << '\n';
-        runFolderStrategy(options.input_path, MergeStrategy::Hierarchy,
-                          options.preview_limit);
+        runFolderStrategy(options.input_path, MergeStrategy::Hierarchy, options);
         break;
       case StrategySelection::Default:
         break;
@@ -243,7 +368,7 @@ int main(int argc, const char *argv[]) {
       if (options.strategy != StrategySelection::Default) {
         usageError("--strategy only valid for directory input");
       }
-      runSingleFile(options.input_path, options.preview_limit);
+      runSingleFile(options.input_path, options);
     }
   } catch (std::exception &ex) {
     std::cerr << "Back-tester threw an exception: " << ex.what() << std::endl;

--- a/test/BookDispatcherTest.cpp
+++ b/test/BookDispatcherTest.cpp
@@ -1,0 +1,99 @@
+#include "common/MarketDataEvent.hpp"
+#include "lob/BookDispatcher.hpp"
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <algorithm>
+
+using namespace cmf;
+
+namespace {
+
+MarketDataEvent makeEvent(std::uint32_t instrument_id, std::uint64_t order_id,
+                          MdAction action, MdSide side, std::int64_t price,
+                          std::uint32_t size, std::uint16_t publisher_id = 1,
+                          std::uint64_t ts_recv = 0) {
+  MarketDataEvent event{};
+  event.instrument_id = instrument_id;
+  event.order_id = order_id;
+  event.action = action;
+  event.side = side;
+  event.price = price;
+  event.size = size;
+  event.publisher_id = publisher_id;
+  event.ts_recv = ts_recv;
+  return event;
+}
+
+} // namespace
+
+TEST_CASE("BookDispatcher routes explicit instrument events and captures snapshots",
+          "[lob][dispatcher]") {
+  BookDispatcher dispatcher(
+      DispatchOptions{.snapshot_every = 2, .max_snapshots = 3, .snapshot_depth = 2});
+
+  dispatcher.apply(
+      makeEvent(10, 101, MdAction::Add, MdSide::Bid, 1'000'000'000LL, 5, 1, 1));
+  dispatcher.apply(
+      makeEvent(11, 201, MdAction::Add, MdSide::Ask, 2'000'000'000LL, 7, 1, 2));
+  dispatcher.apply(makeEvent(10, 101, MdAction::Cancel, MdSide::Bid, UNDEF_PRICE,
+                             2, 1, 3));
+  dispatcher.apply(
+      makeEvent(11, 202, MdAction::Add, MdSide::Ask, 2'100'000'000LL, 3, 1, 4));
+
+  REQUIRE(dispatcher.stats().total_events == 4);
+  REQUIRE(dispatcher.stats().instruments == 2);
+  REQUIRE(dispatcher.stats().snapshots == 3);
+
+  const auto summaries = dispatcher.finalSummaries();
+  REQUIRE(summaries.size() == 2);
+  const auto find_summary = [&](std::uint32_t instrument_id) -> const BookSummary & {
+    const auto it =
+        std::find_if(summaries.begin(), summaries.end(),
+                     [&](const BookSummary &summary) {
+                       return summary.instrument_id == instrument_id;
+                     });
+    REQUIRE(it != summaries.end());
+    return *it;
+  };
+  const BookSummary &book10 = find_summary(10);
+  const BookSummary &book11 = find_summary(11);
+  REQUIRE(book10.orders == 1);
+  REQUIRE(book10.best_bid->size == 3);
+  REQUIRE(book11.best_ask->price == 2'000'000'000LL);
+  REQUIRE(book11.snapshot.find("best_ask=2.000000000x7") != std::string::npos);
+}
+
+TEST_CASE("BookDispatcher resolves missing instrument ids when order is unique",
+          "[lob][dispatcher]") {
+  BookDispatcher dispatcher;
+  dispatcher.apply(
+      makeEvent(42, 700, MdAction::Add, MdSide::Bid, 5'000'000'000LL, 4, 9, 1));
+
+  MarketDataEvent cancel_without_instrument =
+      makeEvent(0, 700, MdAction::Cancel, MdSide::Bid, UNDEF_PRICE, 4, 9, 2);
+  dispatcher.apply(cancel_without_instrument);
+
+  REQUIRE(dispatcher.stats().unresolved_routes == 0);
+  REQUIRE(dispatcher.stats().ambiguous_routes == 0);
+  REQUIRE(dispatcher.finalSummaries()[0].orders == 0);
+}
+
+TEST_CASE("BookDispatcher flags ambiguous missing-instrument routing",
+          "[lob][dispatcher]") {
+  BookDispatcher dispatcher;
+  dispatcher.apply(
+      makeEvent(42, 700, MdAction::Add, MdSide::Bid, 5'000'000'000LL, 4, 9, 1));
+  dispatcher.apply(
+      makeEvent(43, 700, MdAction::Add, MdSide::Ask, 6'000'000'000LL, 2, 9, 2));
+
+  MarketDataEvent cancel_without_instrument =
+      makeEvent(0, 700, MdAction::Cancel, MdSide::Bid, UNDEF_PRICE, 1, 9, 3);
+  dispatcher.apply(cancel_without_instrument);
+
+  REQUIRE(dispatcher.stats().ambiguous_routes == 1);
+  const auto summaries = dispatcher.finalSummaries();
+  REQUIRE(summaries.size() == 2);
+  REQUIRE(summaries[0].orders == 1);
+  REQUIRE(summaries[1].orders == 1);
+}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -19,7 +19,7 @@ add_executable(${TARGET} ${TEST_SRC})
 # Link against the necessary libraries
 target_link_libraries(${TARGET} PRIVATE
     Catch2-static-lib
-    back-tester-common
+    back-tester-ingest
 )
 
 # Register the tests with CTest

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -20,6 +20,7 @@ add_executable(${TARGET} ${TEST_SRC})
 target_link_libraries(${TARGET} PRIVATE
     Catch2-static-lib
     back-tester-ingest
+    back-tester-lob
 )
 
 # Register the tests with CTest

--- a/test/FolderIngestTest.cpp
+++ b/test/FolderIngestTest.cpp
@@ -125,3 +125,23 @@ TEST_CASE("ingestFolder keeps deterministic order for equal event keys",
   REQUIRE(flat_order == expected);
   REQUIRE(hierarchy_order == expected);
 }
+
+TEST_CASE("ingestFolder rejects zero batch_size and zero queue_capacity",
+          "[folder-ingest]") {
+  TempDir dir("back-tester-folder-ingest-zero-opts");
+  writeLines(
+      dir.getPath() / "a.json",
+      {
+          R"({"ts_recv":100,"hd":{"ts_event":100,"rtype":160,"publisher_id":7,"instrument_id":1},"order_id":"1","action":"A","side":"B","price":1,"size":1,"sequence":1})",
+      });
+
+  const auto consumer = [](const MarketDataEvent &) {};
+
+  REQUIRE_THROWS_AS(
+      ingestFolder(dir.getPath(), MergeStrategy::Flat, consumer,
+                   FolderIngestOptions{.queue_capacity = 0}),
+      std::invalid_argument);
+  REQUIRE_THROWS_AS(ingestFolder(dir.getPath(), MergeStrategy::Flat, consumer,
+                                 FolderIngestOptions{.batch_size = 0}),
+                    std::invalid_argument);
+}

--- a/test/FolderIngestTest.cpp
+++ b/test/FolderIngestTest.cpp
@@ -35,11 +35,13 @@ void writeLines(const std::filesystem::path &path,
 
 std::vector<std::uint64_t>
 collectStrategyTimestamps(const std::filesystem::path &folder,
-                          MergeStrategy strategy, FolderIngestStats &stats) {
+                          MergeStrategy strategy, FolderIngestStats &stats,
+                          FolderIngestOptions options = {}) {
   std::vector<std::uint64_t> seen;
-  stats = ingestFolder(folder, strategy, [&](const MarketDataEvent &event) {
-    seen.push_back(event.order_id);
-  });
+  stats = ingestFolder(
+      folder, strategy,
+      [&](const MarketDataEvent &event) { seen.push_back(event.order_id); },
+      options);
   return seen;
 }
 
@@ -70,11 +72,12 @@ TEST_CASE("ingestFolder preserves chronological order for both strategies",
       });
 
   FolderIngestStats flat_stats{};
-  const auto flat_order =
-      collectStrategyTimestamps(dir.getPath(), MergeStrategy::Flat, flat_stats);
+  const FolderIngestOptions tiny_batches{.queue_capacity = 2, .batch_size = 2};
+  const auto flat_order = collectStrategyTimestamps(
+      dir.getPath(), MergeStrategy::Flat, flat_stats, tiny_batches);
   FolderIngestStats hierarchy_stats{};
   const auto hierarchy_order = collectStrategyTimestamps(
-      dir.getPath(), MergeStrategy::Hierarchy, hierarchy_stats);
+      dir.getPath(), MergeStrategy::Hierarchy, hierarchy_stats, tiny_batches);
 
   const std::vector<std::uint64_t> expected{
       1001, 2001, 3001, 1002, 2002, 3002, 1003, 3003};
@@ -111,11 +114,12 @@ TEST_CASE("ingestFolder keeps deterministic order for equal event keys",
       });
 
   FolderIngestStats flat_stats{};
-  const auto flat_order =
-      collectStrategyTimestamps(dir.getPath(), MergeStrategy::Flat, flat_stats);
+  const FolderIngestOptions tiny_batches{.queue_capacity = 1, .batch_size = 1};
+  const auto flat_order = collectStrategyTimestamps(
+      dir.getPath(), MergeStrategy::Flat, flat_stats, tiny_batches);
   FolderIngestStats hierarchy_stats{};
   const auto hierarchy_order = collectStrategyTimestamps(
-      dir.getPath(), MergeStrategy::Hierarchy, hierarchy_stats);
+      dir.getPath(), MergeStrategy::Hierarchy, hierarchy_stats, tiny_batches);
 
   const std::vector<std::uint64_t> expected{11, 22};
   REQUIRE(flat_order == expected);

--- a/test/FolderIngestTest.cpp
+++ b/test/FolderIngestTest.cpp
@@ -1,0 +1,123 @@
+#include "ingest/FolderIngest.hpp"
+#include "common/MarketDataEvent.hpp"
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <fstream>
+
+using namespace cmf;
+
+namespace {
+
+class TempDir {
+public:
+  explicit TempDir(std::string_view name)
+      : path_{std::filesystem::temp_directory_path() / std::string{name}} {
+    std::filesystem::remove_all(path_);
+    std::filesystem::create_directories(path_);
+  }
+
+  ~TempDir() { std::filesystem::remove_all(path_); }
+
+  const std::filesystem::path &getPath() const { return path_; }
+
+private:
+  std::filesystem::path path_;
+};
+
+void writeLines(const std::filesystem::path &path,
+                const std::vector<std::string> &lines) {
+  std::ofstream os(path);
+  for (const auto &line : lines) {
+    os << line << '\n';
+  }
+}
+
+std::vector<std::uint64_t>
+collectStrategyTimestamps(const std::filesystem::path &folder,
+                          MergeStrategy strategy, FolderIngestStats &stats) {
+  std::vector<std::uint64_t> seen;
+  stats = ingestFolder(folder, strategy, [&](const MarketDataEvent &event) {
+    seen.push_back(event.order_id);
+  });
+  return seen;
+}
+
+} // namespace
+
+TEST_CASE("ingestFolder preserves chronological order for both strategies",
+          "[ingest][folder]") {
+  TempDir dir("folder_ingest_order");
+  writeLines(
+      dir.getPath() / "a.json",
+      {
+          R"({"ts_recv":100,"hd":{"ts_event":100,"rtype":160,"publisher_id":1,"instrument_id":1},"order_id":"1001","action":"A","side":"B","price":1,"size":1,"sequence":1})",
+          R"({"ts_recv":103,"hd":{"ts_event":103,"rtype":160,"publisher_id":1,"instrument_id":1},"order_id":"1002","action":"A","side":"B","price":1,"size":1,"sequence":2})",
+          R"({"ts_recv":106,"hd":{"ts_event":106,"rtype":160,"publisher_id":1,"instrument_id":1},"order_id":"1003","action":"A","side":"B","price":1,"size":1,"sequence":3})",
+      });
+  writeLines(
+      dir.getPath() / "b.json",
+      {
+          R"({"ts_recv":101,"hd":{"ts_event":101,"rtype":160,"publisher_id":1,"instrument_id":1},"order_id":"2001","action":"A","side":"B","price":1,"size":1,"sequence":4})",
+          R"({"ts_recv":104,"hd":{"ts_event":104,"rtype":160,"publisher_id":1,"instrument_id":1},"order_id":"2002","action":"A","side":"B","price":1,"size":1,"sequence":5})",
+      });
+  writeLines(
+      dir.getPath() / "c.json",
+      {
+          R"({"ts_recv":102,"hd":{"ts_event":102,"rtype":160,"publisher_id":1,"instrument_id":1},"order_id":"3001","action":"A","side":"B","price":1,"size":1,"sequence":6})",
+          R"({"ts_recv":105,"hd":{"ts_event":105,"rtype":160,"publisher_id":1,"instrument_id":1},"order_id":"3002","action":"A","side":"B","price":1,"size":1,"sequence":7})",
+          R"({"ts_recv":107,"hd":{"ts_event":107,"rtype":160,"publisher_id":1,"instrument_id":1},"order_id":"3003","action":"A","side":"B","price":1,"size":1,"sequence":8})",
+      });
+
+  FolderIngestStats flat_stats{};
+  const auto flat_order =
+      collectStrategyTimestamps(dir.getPath(), MergeStrategy::Flat, flat_stats);
+  FolderIngestStats hierarchy_stats{};
+  const auto hierarchy_order = collectStrategyTimestamps(
+      dir.getPath(), MergeStrategy::Hierarchy, hierarchy_stats);
+
+  const std::vector<std::uint64_t> expected{
+      1001, 2001, 3001, 1002, 2002, 3002, 1003, 3003};
+  REQUIRE(flat_order == expected);
+  REQUIRE(hierarchy_order == expected);
+
+  REQUIRE(flat_stats.files == 3);
+  REQUIRE(flat_stats.total == expected.size());
+  REQUIRE(flat_stats.skipped_rtype == 0);
+  REQUIRE(flat_stats.skipped_parse == 0);
+  REQUIRE(flat_stats.out_of_order_ts_recv == 0);
+  REQUIRE(flat_stats.first_ts_recv == 100);
+  REQUIRE(flat_stats.last_ts_recv == 107);
+
+  REQUIRE(hierarchy_stats.files == 3);
+  REQUIRE(hierarchy_stats.total == expected.size());
+  REQUIRE(hierarchy_stats.skipped_rtype == 0);
+  REQUIRE(hierarchy_stats.skipped_parse == 0);
+  REQUIRE(hierarchy_stats.out_of_order_ts_recv == 0);
+}
+
+TEST_CASE("ingestFolder keeps deterministic order for equal event keys",
+          "[ingest][folder]") {
+  TempDir dir("folder_ingest_equal_keys");
+  writeLines(
+      dir.getPath() / "a.json",
+      {
+          R"({"ts_recv":500,"hd":{"ts_event":500,"rtype":160,"publisher_id":7,"instrument_id":1},"order_id":"11","action":"A","side":"B","price":1,"size":1,"sequence":9})",
+      });
+  writeLines(
+      dir.getPath() / "b.json",
+      {
+          R"({"ts_recv":500,"hd":{"ts_event":500,"rtype":160,"publisher_id":7,"instrument_id":1},"order_id":"22","action":"A","side":"B","price":1,"size":1,"sequence":9})",
+      });
+
+  FolderIngestStats flat_stats{};
+  const auto flat_order =
+      collectStrategyTimestamps(dir.getPath(), MergeStrategy::Flat, flat_stats);
+  FolderIngestStats hierarchy_stats{};
+  const auto hierarchy_order = collectStrategyTimestamps(
+      dir.getPath(), MergeStrategy::Hierarchy, hierarchy_stats);
+
+  const std::vector<std::uint64_t> expected{11, 22};
+  REQUIRE(flat_order == expected);
+  REQUIRE(hierarchy_order == expected);
+}

--- a/test/LimitOrderBookTest.cpp
+++ b/test/LimitOrderBookTest.cpp
@@ -1,0 +1,80 @@
+#include "common/MarketDataEvent.hpp"
+#include "lob/LimitOrderBook.hpp"
+
+#include <catch2/catch_test_macros.hpp>
+
+using namespace cmf;
+
+namespace {
+
+MarketDataEvent makeEvent(std::uint32_t instrument_id, std::uint64_t order_id,
+                          MdAction action, MdSide side, std::int64_t price,
+                          std::uint32_t size, std::uint16_t publisher_id = 1) {
+  MarketDataEvent event{};
+  event.instrument_id = instrument_id;
+  event.order_id = order_id;
+  event.action = action;
+  event.side = side;
+  event.price = price;
+  event.size = size;
+  event.publisher_id = publisher_id;
+  return event;
+}
+
+} // namespace
+
+TEST_CASE("LimitOrderBook rebuilds aggregated bid and ask levels", "[lob]") {
+  LimitOrderBook book(77);
+
+  REQUIRE(book.apply(makeEvent(77, 11, MdAction::Add, MdSide::Bid,
+                               1'100'000'000LL, 5))
+              .missing_order == false);
+  book.apply(makeEvent(77, 12, MdAction::Add, MdSide::Bid, 1'100'000'000LL, 7));
+  book.apply(makeEvent(77, 21, MdAction::Add, MdSide::Ask, 1'200'000'000LL, 9));
+
+  REQUIRE(book.volumeAtPrice(MdSide::Bid, 1'100'000'000LL) == 12);
+  REQUIRE(book.volumeAtPrice(MdSide::Ask, 1'200'000'000LL) == 9);
+  REQUIRE(book.bestBid()->price == 1'100'000'000LL);
+  REQUIRE(book.bestBid()->size == 12);
+  REQUIRE(book.bestAsk()->price == 1'200'000'000LL);
+  REQUIRE(book.bestAsk()->size == 9);
+
+  book.apply(makeEvent(77, 11, MdAction::Modify, MdSide::Bid, 1'150'000'000LL,
+                       3));
+  REQUIRE(book.volumeAtPrice(MdSide::Bid, 1'100'000'000LL) == 7);
+  REQUIRE(book.volumeAtPrice(MdSide::Bid, 1'150'000'000LL) == 3);
+  REQUIRE(book.bestBid()->price == 1'150'000'000LL);
+  REQUIRE(book.bestBid()->size == 3);
+
+  book.apply(makeEvent(77, 21, MdAction::Cancel, MdSide::Ask, UNDEF_PRICE, 4));
+  REQUIRE(book.volumeAtPrice(MdSide::Ask, 1'200'000'000LL) == 5);
+
+  book.apply(makeEvent(77, 0, MdAction::Trade, MdSide::None, 1'180'000'000LL,
+                       2));
+  book.apply(makeEvent(77, 21, MdAction::Fill, MdSide::Ask, 1'200'000'000LL,
+                       2));
+  REQUIRE(book.volumeAtPrice(MdSide::Ask, 1'200'000'000LL) == 5);
+
+  book.apply(makeEvent(77, 0, MdAction::Clear, MdSide::None, UNDEF_PRICE, 0));
+  REQUIRE_FALSE(book.bestBid().has_value());
+  REQUIRE_FALSE(book.bestAsk().has_value());
+  REQUIRE(book.orderCount() == 0);
+}
+
+TEST_CASE("LimitOrderBook reports missing orders and keeps prior fields on modify",
+          "[lob]") {
+  LimitOrderBook book(88);
+  book.apply(makeEvent(88, 31, MdAction::Add, MdSide::Ask, 2'000'000'000LL, 6));
+
+  MarketDataEvent keep_price =
+      makeEvent(88, 31, MdAction::Modify, MdSide::None, UNDEF_PRICE, 4);
+  const ApplyResult keep_price_result = book.apply(keep_price);
+  REQUIRE_FALSE(keep_price_result.missing_order);
+  REQUIRE(book.bestAsk()->price == 2'000'000'000LL);
+  REQUIRE(book.bestAsk()->size == 4);
+
+  const ApplyResult missing = book.apply(
+      makeEvent(88, 99, MdAction::Cancel, MdSide::Ask, UNDEF_PRICE, 1));
+  REQUIRE(missing.missing_order);
+  REQUIRE(book.orderCount() == 1);
+}

--- a/test/MarketDataEventTest.cpp
+++ b/test/MarketDataEventTest.cpp
@@ -1,0 +1,82 @@
+#include "common/MarketDataEvent.hpp"
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <sstream>
+
+using namespace cmf;
+
+TEST_CASE("MarketDataEvent defaults carry sentinels", "[mde]") {
+  MarketDataEvent e;
+  REQUIRE(e.ts_recv == UNDEF_TIMESTAMP);
+  REQUIRE(e.ts_event == UNDEF_TIMESTAMP);
+  REQUIRE(e.price == UNDEF_PRICE);
+  REQUIRE(e.size == 0);
+  REQUIRE(e.action == MdAction::None);
+  REQUIRE(e.side == MdSide::None);
+}
+
+TEST_CASE(
+    "MarketDataEvent comparator orders by ts_recv, publisher_id, sequence",
+    "[mde]") {
+  MarketDataEvent a{};
+  a.ts_recv = 100;
+  a.publisher_id = 1;
+  a.sequence = 10;
+
+  MarketDataEvent b = a;
+  b.ts_recv = 101;
+  REQUIRE(a < b);
+
+  MarketDataEvent c = a;
+  c.publisher_id = 2;
+  REQUIRE(a < c);
+  REQUIRE(c < b); // ts_recv dominates
+
+  MarketDataEvent d = a;
+  d.sequence = 11;
+  REQUIRE(a < d);
+}
+
+TEST_CASE("MarketDataEvent equality uses the same key as the comparator",
+          "[mde]") {
+  MarketDataEvent a{};
+  a.ts_recv = 42;
+  a.publisher_id = 3;
+  a.sequence = 7;
+  // differ in fields outside the key — comparator should treat as equal
+  MarketDataEvent b = a;
+  b.order_id = 99999;
+  b.price = 123;
+  b.size = 5;
+  REQUIRE(a == b);
+  REQUIRE_FALSE(a < b);
+  REQUIRE_FALSE(b < a);
+}
+
+TEST_CASE("MarketDataEvent price preserves int64 fixed precision", "[mde]") {
+  MarketDataEvent e{};
+  e.ts_recv = 1;
+  e.order_id = 42;
+  e.price = 5'411'750'000'000LL; // 5411.75 per Databento documentation
+  e.size = 3;
+  e.action = MdAction::Add;
+  e.side = MdSide::Bid;
+
+  std::ostringstream os;
+  os << e;
+  const std::string out = os.str();
+  REQUIRE(out.find("price=5411.750000000") != std::string::npos);
+  REQUIRE(out.find("order_id=42") != std::string::npos);
+  REQUIRE(out.find("action=A") != std::string::npos);
+  REQUIRE(out.find("side=B") != std::string::npos);
+  REQUIRE(out.find("size=3") != std::string::npos);
+  REQUIRE(out.find("ts_recv=1") != std::string::npos);
+}
+
+TEST_CASE("MarketDataEvent undef price renders as null", "[mde]") {
+  MarketDataEvent e{};
+  std::ostringstream os;
+  os << e;
+  REQUIRE(os.str().find("price=null") != std::string::npos);
+}

--- a/test/MarketDataEventTest.cpp
+++ b/test/MarketDataEventTest.cpp
@@ -38,20 +38,23 @@ TEST_CASE(
   REQUIRE(a < d);
 }
 
-TEST_CASE("MarketDataEvent equality uses the same key as the comparator",
-          "[mde]") {
+TEST_CASE("MarketDataEvent exposes order-key equivalence explicitly", "[mde]") {
   MarketDataEvent a{};
   a.ts_recv = 42;
   a.publisher_id = 3;
   a.sequence = 7;
-  // differ in fields outside the key — comparator should treat as equal
+  // Differ in fields outside the key — sameOrderKey should treat as equal.
   MarketDataEvent b = a;
   b.order_id = 99999;
   b.price = 123;
   b.size = 5;
-  REQUIRE(a == b);
+  REQUIRE(sameOrderKey(a, b));
   REQUIRE_FALSE(a < b);
   REQUIRE_FALSE(b < a);
+
+  MarketDataEvent c = a;
+  c.sequence = 8;
+  REQUIRE_FALSE(sameOrderKey(a, c));
 }
 
 TEST_CASE("MarketDataEvent price preserves int64 fixed precision", "[mde]") {

--- a/test/NdjsonReaderTest.cpp
+++ b/test/NdjsonReaderTest.cpp
@@ -1,0 +1,109 @@
+#include "ingest/NdjsonReader.hpp"
+#include "TempFile.hpp"
+#include "common/MarketDataEvent.hpp"
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <fstream>
+#include <vector>
+
+using namespace cmf;
+
+namespace {
+
+void writeLines(const std::filesystem::path &p,
+                const std::vector<std::string> &lines) {
+  std::ofstream os(p);
+  for (const auto &line : lines) {
+    os << line << '\n';
+  }
+}
+
+} // namespace
+
+TEST_CASE("parseNdjsonFile ingests MBO lines and skips non-MBO / malformed",
+          "[ingest]") {
+  TempFile tmp("ndjson_reader_test.ndjson");
+  writeLines(
+      tmp.getPath(),
+      {
+          R"({"ts_recv":"2026-03-10T00:03:00.166748445Z","hd":{"ts_event":"2026-03-10T00:00:00.000000000Z","rtype":160,"publisher_id":101,"instrument_id":642004},"action":"R","side":"N","price":null,"size":0,"channel_id":23,"order_id":"0","flags":8,"ts_in_delta":0,"sequence":0})",
+          R"({"ts_recv":"2026-03-10T00:03:00.166748445Z","hd":{"ts_event":"2026-03-10T00:00:00.000000000Z","rtype":160,"publisher_id":101,"instrument_id":642004},"action":"A","side":"B","price":"-0.005250000","size":10,"channel_id":23,"order_id":"10996472836897837169","flags":0,"ts_in_delta":2453,"sequence":29622})",
+          R"({"ts_recv":"2026-03-10T00:36:29.559291401Z","hd":{"ts_event":"2026-03-10T00:36:29.559245905Z","rtype":160,"publisher_id":101,"instrument_id":642004},"action":"A","side":"A","price":"-0.004870000","size":10,"channel_id":23,"order_id":"1773102989559258459","flags":128,"ts_in_delta":1083,"sequence":37599})",
+          R"({"ts_recv":"2026-03-10T00:36:29.559291401Z","hd":{"ts_event":"2026-03-10T00:36:29.559245905Z","rtype":1,"publisher_id":101,"instrument_id":642004},"action":"A","side":"A","price":"-0.004870000","size":10,"channel_id":23,"order_id":"1773102989559258459","flags":128,"ts_in_delta":1083,"sequence":37600})",
+          R"(this is not json at all)",
+      });
+
+  std::vector<MarketDataEvent> seen;
+  const auto stats = parseNdjsonFile(
+      tmp.getPath(), [&](const MarketDataEvent &e) { seen.push_back(e); });
+
+  REQUIRE(stats.consumed == 3);
+  REQUIRE(stats.skipped_rtype == 1);
+  REQUIRE(stats.skipped_parse == 1);
+  REQUIRE(stats.first_ts_recv == 1'773'100'980'166'748'445ULL);
+  REQUIRE(stats.last_ts_recv == 1'773'102'989'559'291'401ULL);
+  // Informational: deliberately ordered input, counter should be zero.
+  REQUIRE(stats.out_of_order_ts_recv == 0);
+
+  REQUIRE(seen.size() == 3);
+  REQUIRE(seen[0].order_id == 0);
+  REQUIRE(seen[0].price == UNDEF_PRICE);
+  REQUIRE(seen[0].action == MdAction::Clear);
+  REQUIRE(seen[0].side == MdSide::None);
+  REQUIRE(seen[1].order_id == 10'996'472'836'897'837'169ULL);
+  REQUIRE(seen[1].action == MdAction::Add);
+  REQUIRE(seen[1].side == MdSide::Bid);
+  REQUIRE(seen[1].price == -5'250'000LL);
+  REQUIRE(seen[2].action == MdAction::Add);
+  REQUIRE(seen[2].price == -4'870'000LL);
+  REQUIRE(seen[2].publisher_id == 101);
+  REQUIRE(seen[2].instrument_id == 642'004U);
+}
+
+TEST_CASE("parseNdjsonFile accepts legacy top-level integer fields",
+          "[ingest]") {
+  TempFile tmp("ndjson_reader_rtype_str.ndjson");
+  writeLines(
+      tmp.getPath(),
+      {
+          R"({"rtype":"mbo","ts_recv":500,"ts_event":499,"publisher_id":2,"instrument_id":7,"order_id":"1","action":"A","side":"A","price":1000000000,"size":1,"sequence":1})",
+      });
+
+  MarketDataEvent event{};
+  std::size_t count = 0;
+  const auto stats =
+      parseNdjsonFile(tmp.getPath(), [&](const MarketDataEvent &e) {
+        ++count;
+        event = e;
+      });
+
+  REQUIRE(stats.consumed == 1);
+  REQUIRE(count == 1);
+  REQUIRE(stats.skipped_rtype == 0);
+  REQUIRE(stats.skipped_parse == 0);
+  REQUIRE(event.ts_recv == 500);
+  REQUIRE(event.ts_event == 499);
+  REQUIRE(event.price == 1'000'000'000LL);
+  REQUIRE(event.publisher_id == 2);
+}
+
+TEST_CASE("parseNdjsonFile counts out-of-order ts_recv without failing",
+          "[ingest]") {
+  TempFile tmp("ndjson_reader_ooo.ndjson");
+  writeLines(
+      tmp.getPath(),
+      {
+          R"({"ts_recv":"2026-03-10T00:00:00.000000001Z","hd":{"ts_event":"2026-03-10T00:00:00.000000000Z","rtype":160,"publisher_id":1,"instrument_id":1},"order_id":"1","action":"A","side":"B","price":"0.000000000","size":1,"sequence":1})",
+          R"({"ts_recv":"2026-03-10T00:00:00.000000000Z","hd":{"ts_event":"2026-03-10T00:00:00.000000000Z","rtype":160,"publisher_id":1,"instrument_id":1},"order_id":"2","action":"A","side":"B","price":"0.000000000","size":1,"sequence":2})",
+          R"({"ts_recv":"2026-03-10T00:00:00.000000002Z","hd":{"ts_event":"2026-03-10T00:00:00.000000000Z","rtype":160,"publisher_id":1,"instrument_id":1},"order_id":"3","action":"A","side":"B","price":"0.000000000","size":1,"sequence":3})",
+      });
+
+  const auto stats =
+      parseNdjsonFile(tmp.getPath(), [](const MarketDataEvent &) {});
+
+  REQUIRE(stats.consumed == 3);
+  REQUIRE(stats.out_of_order_ts_recv == 1);
+  REQUIRE(stats.first_ts_recv == 1'773'100'800'000'000'001ULL);
+  REQUIRE(stats.last_ts_recv == 1'773'100'800'000'000'002ULL);
+}


### PR DESCRIPTION
## Summary

- add a per-instrument `LimitOrderBook` that rebuilds aggregated L2 state
  from Databento MBO events
- add a sequential `BookDispatcher` that routes merged events, captures
  bounded snapshots, and reports final BBO plus diagnostics
- wire the existing single-file and folder ingest paths through the new
  dispatcher without changing chronological guarantees
- add unit coverage for book semantics and instrument routing
- add a small NDJSON-to-Feather conversion helper for homework 2 workflows

## Validation

- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build --output-on-failure`
- real-data smoke on two sample daily Databento MBO files:
  - single-file replay processed `749817` events at about `394793 msgs/sec`
  - two-file folder replay preserved order for both merge strategies
  - flat merge ran at about `465452 msgs/sec`
  - hierarchy merge ran at about `668533 msgs/sec`

## Test Plan

- verify unit coverage for book updates and missing-instrument routing
- replay one real `.mbo.json` file and inspect bounded LOB snapshots plus
  final BBO summaries
- replay a small folder with both merge strategies and confirm dispatch
  order plus strategy stats remain sane
- run the Feather conversion helper on one real `.mbo.json` file and check
  that the resulting `.feather` file opens with Arrow tooling

## Acceptance Criteria Proposal

- one LOB is maintained per instrument and all updates stay sequential
- `Add`, `Cancel`, `Modify`, `Trade`, `Fill`, and `Clear` handling is either
  covered by tests or explicitly treated as no-op where appropriate
- CLI output includes bounded snapshots, final BBO summaries, and
  performance statistics
- both folder merge strategies preserve strict chronological dispatch
- a documented helper exists for NDJSON-to-Feather conversion

Assisted-by: Claude:claude-opus-4-7 Codex:GPT-5.4
