### PR TITLE
feat(market-data): add feed fanout (HW3 Group 2)

### DIFF
--- a/bench/CMakeLists.txt
+++ b/bench/CMakeLists.txt
@@ -7,6 +7,7 @@ add_executable(${TARGET} ${BENCH_SRC})
 target_link_libraries(${TARGET} PRIVATE
     googlebenchmark-static-lib
     back-tester-ingestion
+    back-tester-market-data-feed
     back-tester-order-book
     Threads::Threads
 )

--- a/bench/MarketDataFeedBench.cpp
+++ b/bench/MarketDataFeedBench.cpp
@@ -1,0 +1,65 @@
+#include "market_data_feed/MarketDataFeed.hpp"
+
+#include <benchmark/benchmark.h>
+
+#include <memory>
+#include <vector>
+
+namespace
+{
+
+cmf::BookUpdate make_update(uint64_t seq_no)
+{
+    return cmf::BookUpdate{.instrument_id = 10,
+                           .timestamp_ns = static_cast<cmf::NanoTime>(seq_no),
+                           .seq_no = seq_no,
+                           .side = cmf::Side::Buy,
+                           .price = 100'000'000'000 + static_cast<int64_t>(seq_no),
+                           .size = 100};
+}
+
+} // namespace
+
+static void BM_MarketDataFeed_PublishDrain(benchmark::State& state)
+{
+    const auto event_count = static_cast<uint64_t>(state.range(0));
+    const auto subscriber_count = static_cast<std::size_t>(state.range(1));
+
+    for (auto _ : state)
+    {
+        cmf::MarketDataFeed<(1 << 15)> feed;
+        std::vector<uint64_t> delivered(subscriber_count, 0);
+        std::vector<cmf::MarketDataFeed<(1 << 15)>::Subscription> subscriptions;
+        subscriptions.reserve(subscriber_count);
+
+        for (std::size_t i = 0; i < subscriber_count; ++i)
+        {
+            subscriptions.push_back(feed.subscribe(
+                10, [&delivered, i](const cmf::MarketDataMessage&,
+                                    const cmf::FeedStatus&)
+                { ++delivered[i]; }));
+        }
+
+        for (uint64_t seq_no = 1; seq_no <= event_count; ++seq_no)
+            feed.publishUpdate(make_update(seq_no));
+
+        for (auto& subscription : subscriptions)
+            benchmark::DoNotOptimize(subscription.drain());
+
+        benchmark::DoNotOptimize(delivered);
+    }
+
+    state.SetItemsProcessed(state.iterations() * event_count *
+                            subscriber_count);
+}
+
+BENCHMARK(BM_MarketDataFeed_PublishDrain)
+    ->Name("MarketDataFeed/PublishDrain")
+    ->Args({1 << 10, 1})
+    ->Args({1 << 10, 2})
+    ->Args({1 << 10, 4})
+    ->Args({1 << 10, 8})
+    ->Unit(benchmark::kMicrosecond)
+    ->MinWarmUpTime(0.1)
+    ->MinTime(0.2)
+    ->UseRealTime();

--- a/bench/MarketDataFeedReplayBench.cpp
+++ b/bench/MarketDataFeedReplayBench.cpp
@@ -1,0 +1,229 @@
+#include "ingestion/JsonNativeDataParser.hpp"
+#include "market_data_feed/MarketDataFeed.hpp"
+
+#include <benchmark/benchmark.h>
+
+#include <algorithm>
+#include <array>
+#include <cstdlib>
+#include <filesystem>
+#include <string>
+#include <vector>
+
+namespace
+{
+
+constexpr std::size_t QueueCapacity = 1 << 15;
+constexpr uint64_t DrainEvery = 1024;
+
+std::vector<std::filesystem::path> replay_files(benchmark::State& state)
+{
+    const char* bench_dir_env = std::getenv("BENCH_DIR");
+    if (bench_dir_env == nullptr)
+    {
+        state.SkipWithError("BENCH_DIR env var not set.");
+        return {};
+    }
+
+    const std::filesystem::path bench_dir{bench_dir_env};
+    if (!std::filesystem::is_directory(bench_dir))
+    {
+        state.SkipWithError("BENCH_DIR is not a directory: " +
+                            bench_dir.string());
+        return {};
+    }
+
+    std::vector<std::filesystem::path> files;
+    for (const auto& entry :
+         std::filesystem::recursive_directory_iterator{bench_dir})
+    {
+        if (!entry.is_regular_file())
+            continue;
+
+        const auto path = entry.path();
+        if (path.string().ends_with(cmf::JsonNativeDataParser::filename_ext))
+            files.push_back(path);
+    }
+
+    std::sort(files.begin(), files.end());
+
+    std::size_t file_limit = 20;
+    if (const char* limit_env = std::getenv("BENCH_FILE_LIMIT");
+        limit_env != nullptr)
+    {
+        file_limit = std::stoull(limit_env);
+    }
+
+    if (files.size() < file_limit)
+    {
+        state.SkipWithError("BENCH_DIR has fewer replay files than requested.");
+        return {};
+    }
+
+    files.resize(file_limit);
+    return files;
+}
+
+cmf::MarketDataMessage to_feed_message(const cmf::MarketDataEvent& event)
+{
+    cmf::MarketDataMessage message;
+    if (event.action == cmf::Action::Trade || event.action == cmf::Action::Fill)
+    {
+        message.type = cmf::MarketDataMessageType::Trade;
+        message.trade = cmf::Trade{.instrument_id = event.instrument_id,
+                                   .timestamp_ns = event.ts_recv,
+                                   .seq_no = event.sequence,
+                                   .side = event.side,
+                                   .price = event.price,
+                                   .size = event.size};
+        return message;
+    }
+
+    message.type = cmf::MarketDataMessageType::BookUpdate;
+    message.update = cmf::BookUpdate{.instrument_id = event.instrument_id,
+                                     .timestamp_ns = event.ts_recv,
+                                     .seq_no = event.sequence,
+                                     .side = event.side,
+                                     .price = event.price,
+                                     .size = event.size};
+    return message;
+}
+
+void publish_message(cmf::MarketDataFeed<QueueCapacity>& feed,
+                     const cmf::MarketDataMessage& message)
+{
+    switch (message.type)
+    {
+    case cmf::MarketDataMessageType::BookUpdate:
+        feed.publishUpdate(message.update);
+        break;
+    case cmf::MarketDataMessageType::BookSnapshot:
+        feed.publishSnapshot(message.snapshot);
+        break;
+    case cmf::MarketDataMessageType::Trade:
+        feed.publishTrade(message.trade);
+        break;
+    }
+}
+
+} // namespace
+
+static void BM_MarketDataFeedReplay_ParseOnly(benchmark::State& state)
+{
+    const auto files = replay_files(state);
+    if (files.empty())
+        return;
+
+    uint64_t total_events = 0;
+    for (auto _ : state)
+    {
+        uint64_t event_count = 0;
+        for (const auto& file : files)
+        {
+            cmf::JsonNativeDataParser parser{file};
+            parser.parse(
+                [&](const cmf::MarketDataEvent&)
+                { ++event_count; });
+        }
+        benchmark::DoNotOptimize(event_count);
+        total_events = event_count;
+    }
+
+    state.SetItemsProcessed(state.iterations() * total_events);
+    state.counters["source_events"] = benchmark::Counter(
+        static_cast<double>(total_events), benchmark::Counter::kAvgIterations);
+}
+
+static void BM_MarketDataFeedReplay_ParseAndFanout(benchmark::State& state)
+{
+    const auto files = replay_files(state);
+    if (files.empty())
+        return;
+
+    const auto subscriber_count = static_cast<std::size_t>(state.range(0));
+    uint64_t total_events = 0;
+    uint64_t total_delivered = 0;
+    uint64_t total_gaps = 0;
+
+    for (auto _ : state)
+    {
+        cmf::MarketDataFeed<QueueCapacity> feed;
+        std::vector<cmf::MarketDataFeed<QueueCapacity>::Subscription>
+            subscriptions;
+        std::vector<uint64_t> delivered(subscriber_count, 0);
+        uint64_t gap_count = 0;
+        subscriptions.reserve(subscriber_count);
+
+        for (std::size_t i = 0; i < subscriber_count; ++i)
+        {
+            subscriptions.push_back(feed.subscribe(
+                0, [&delivered, &gap_count, i](const cmf::MarketDataMessage&,
+                                               const cmf::FeedStatus& status)
+                {
+                    ++delivered[i];
+                    if (status.has_gap)
+                        ++gap_count;
+                }));
+        }
+
+        uint64_t event_count = 0;
+        uint64_t pending_since_drain = 0;
+        for (const auto& file : files)
+        {
+            cmf::JsonNativeDataParser parser{file};
+            parser.parse(
+                [&](const cmf::MarketDataEvent& event)
+                {
+                    auto message = to_feed_message(event);
+                    message.update.instrument_id = 0;
+                    message.trade.instrument_id = 0;
+                    publish_message(feed, message);
+                    ++event_count;
+                    ++pending_since_drain;
+
+                    if (pending_since_drain == DrainEvery)
+                    {
+                        for (auto& subscription : subscriptions)
+                            benchmark::DoNotOptimize(subscription.drain());
+                        pending_since_drain = 0;
+                    }
+                });
+        }
+
+        for (auto& subscription : subscriptions)
+            benchmark::DoNotOptimize(subscription.drain());
+
+        uint64_t delivered_count = 0;
+        for (const auto count : delivered)
+            delivered_count += count;
+
+        benchmark::DoNotOptimize(delivered_count);
+        total_events = event_count;
+        total_delivered = delivered_count;
+        total_gaps = gap_count;
+    }
+
+    state.SetItemsProcessed(state.iterations() * total_delivered);
+    state.counters["source_events"] = benchmark::Counter(
+        static_cast<double>(total_events), benchmark::Counter::kAvgIterations);
+    state.counters["delivered"] = benchmark::Counter(
+        static_cast<double>(total_delivered), benchmark::Counter::kAvgIterations);
+    state.counters["gaps"] = benchmark::Counter(static_cast<double>(total_gaps),
+                                                benchmark::Counter::kAvgIterations);
+}
+
+BENCHMARK(BM_MarketDataFeedReplay_ParseOnly)
+    ->Name("MarketDataFeedReplay/ParseOnly20Files")
+    ->Unit(benchmark::kSecond)
+    ->Iterations(1)
+    ->UseRealTime();
+
+BENCHMARK(BM_MarketDataFeedReplay_ParseAndFanout)
+    ->Name("MarketDataFeedReplay/ParseAndFanout20Files")
+    ->Arg(1)
+    ->Arg(2)
+    ->Arg(4)
+    ->Arg(8)
+    ->Unit(benchmark::kSecond)
+    ->Iterations(1)
+    ->UseRealTime();

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_subdirectory(common)
 add_subdirectory(ingestion)
+add_subdirectory(market_data_feed)
 add_subdirectory(order_book)
 add_subdirectory(main)

--- a/src/market_data_feed/CMakeLists.txt
+++ b/src/market_data_feed/CMakeLists.txt
@@ -1,0 +1,5 @@
+file(GLOB SRC CONFIGURE_DEPENDS *.cpp)
+
+set(TARGET back-tester-market-data-feed)
+add_library(${TARGET} STATIC ${SRC})
+target_link_libraries(${TARGET} PUBLIC back-tester-common)

--- a/src/market_data_feed/MarketDataFeed.cpp
+++ b/src/market_data_feed/MarketDataFeed.cpp
@@ -1,0 +1,1 @@
+#include "MarketDataFeed.hpp"

--- a/src/market_data_feed/MarketDataFeed.hpp
+++ b/src/market_data_feed/MarketDataFeed.hpp
@@ -1,0 +1,287 @@
+#pragma once
+
+#include "common/BasicTypes.hpp"
+#include "common/LockFreeQueue.hpp"
+
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <stdexcept>
+#include <vector>
+
+namespace cmf
+{
+
+struct BookLevel
+{
+    Side side = Side::None;
+    ScaledPrice price = 0;
+    uint32_t size = 0;
+};
+
+struct BookUpdate
+{
+    uint32_t instrument_id = 0;
+    NanoTime timestamp_ns = 0;
+    uint64_t seq_no = 0;
+    Side side = Side::None;
+    ScaledPrice price = 0;
+    uint32_t size = 0;
+};
+
+struct BookSnapshot
+{
+    uint32_t instrument_id = 0;
+    NanoTime timestamp_ns = 0;
+    uint64_t seq_no = 0;
+    std::vector<BookLevel> levels;
+};
+
+struct Trade
+{
+    uint32_t instrument_id = 0;
+    NanoTime timestamp_ns = 0;
+    uint64_t seq_no = 0;
+    Side side = Side::None;
+    ScaledPrice price = 0;
+    uint32_t size = 0;
+};
+
+enum class MarketDataMessageType
+{
+    BookUpdate,
+    BookSnapshot,
+    Trade,
+};
+
+struct MarketDataMessage
+{
+    MarketDataMessageType type = MarketDataMessageType::BookUpdate;
+    BookUpdate update;
+    BookSnapshot snapshot;
+    Trade trade;
+
+    [[nodiscard]] uint32_t instrument_id() const noexcept;
+    [[nodiscard]] uint64_t seq_no() const noexcept;
+};
+
+struct FeedStatus
+{
+    bool has_gap = false;
+    uint64_t expected_seq_no = 0;
+    uint64_t received_seq_no = 0;
+};
+
+template <std::size_t QueueCapacity = 8192>
+class MarketDataFeed
+{
+  private:
+    using Queue = LockFreeQueue<MarketDataMessage, QueueCapacity>;
+
+    struct SubscriberState
+    {
+        uint32_t instrument_id = 0;
+        std::function<void(const MarketDataMessage&, const FeedStatus&)> callback;
+        Queue queue;
+        std::atomic<bool> active{true};
+        bool has_last_seq = false;
+        uint64_t last_seq_no = 0;
+    };
+
+  public:
+    class Subscription
+    {
+      public:
+        Subscription() = default;
+        explicit Subscription(std::weak_ptr<SubscriberState> state)
+            : state_(std::move(state)) {}
+        ~Subscription() { close(); }
+
+        Subscription(const Subscription&) = delete;
+        Subscription& operator=(const Subscription&) = delete;
+
+        Subscription(Subscription&& other) noexcept
+            : state_(std::move(other.state_))
+        {
+            other.state_.reset();
+        }
+
+        Subscription& operator=(Subscription&& other) noexcept
+        {
+            if (this != &other)
+            {
+                close();
+                state_ = std::move(other.state_);
+                other.state_.reset();
+            }
+            return *this;
+        }
+
+        [[nodiscard]] std::size_t drain();
+        void close() noexcept;
+
+      private:
+        std::weak_ptr<SubscriberState> state_;
+    };
+
+    [[nodiscard]] Subscription subscribe(
+        uint32_t instrument_id,
+        std::function<void(const MarketDataMessage&, const FeedStatus&)> callback);
+
+    void publishUpdate(const BookUpdate& update);
+    void publishSnapshot(const BookSnapshot& snapshot);
+    void publishTrade(const Trade& trade);
+
+  private:
+    void publish(const MarketDataMessage& message);
+
+    std::mutex subscribers_mutex_;
+    std::vector<std::shared_ptr<SubscriberState>> subscribers_;
+};
+
+inline uint32_t MarketDataMessage::instrument_id() const noexcept
+{
+    switch (type)
+    {
+    case MarketDataMessageType::BookUpdate:
+        return update.instrument_id;
+    case MarketDataMessageType::BookSnapshot:
+        return snapshot.instrument_id;
+    case MarketDataMessageType::Trade:
+        return trade.instrument_id;
+    }
+    return 0;
+}
+
+inline uint64_t MarketDataMessage::seq_no() const noexcept
+{
+    switch (type)
+    {
+    case MarketDataMessageType::BookUpdate:
+        return update.seq_no;
+    case MarketDataMessageType::BookSnapshot:
+        return snapshot.seq_no;
+    case MarketDataMessageType::Trade:
+        return trade.seq_no;
+    }
+    return 0;
+}
+
+template <std::size_t QueueCapacity>
+std::size_t MarketDataFeed<QueueCapacity>::Subscription::drain()
+{
+    auto state = state_.lock();
+    if (!state || !state->active.load(std::memory_order_acquire))
+        return 0;
+
+    std::size_t drained = 0;
+    while (!state->queue.empty())
+    {
+        const bool popped = state->queue.pop(
+            [&](MarketDataMessage&& message)
+            {
+                FeedStatus status;
+                const uint64_t seq_no = message.seq_no();
+                if (state->has_last_seq && seq_no != state->last_seq_no + 1)
+                {
+                    status.has_gap = true;
+                    status.expected_seq_no = state->last_seq_no + 1;
+                    status.received_seq_no = seq_no;
+                }
+                state->last_seq_no = seq_no;
+                state->has_last_seq = true;
+                state->callback(message, status);
+                ++drained;
+            });
+        if (!popped)
+            break;
+    }
+    return drained;
+}
+
+template <std::size_t QueueCapacity>
+void MarketDataFeed<QueueCapacity>::Subscription::close() noexcept
+{
+    auto state = state_.lock();
+    if (!state)
+        return;
+    if (state->active.exchange(false, std::memory_order_acq_rel))
+    {
+        state->queue.close();
+    }
+    state_.reset();
+}
+
+template <std::size_t QueueCapacity>
+typename MarketDataFeed<QueueCapacity>::Subscription
+MarketDataFeed<QueueCapacity>::subscribe(
+    uint32_t instrument_id,
+    std::function<void(const MarketDataMessage&, const FeedStatus&)> callback)
+{
+    auto state = std::make_shared<SubscriberState>();
+    state->instrument_id = instrument_id;
+    state->callback = std::move(callback);
+
+    {
+        std::scoped_lock lock{subscribers_mutex_};
+        subscribers_.push_back(state);
+    }
+
+    return Subscription{state};
+}
+
+template <std::size_t QueueCapacity>
+void MarketDataFeed<QueueCapacity>::publishUpdate(const BookUpdate& update)
+{
+    MarketDataMessage message;
+    message.type = MarketDataMessageType::BookUpdate;
+    message.update = update;
+    publish(message);
+}
+
+template <std::size_t QueueCapacity>
+void MarketDataFeed<QueueCapacity>::publishSnapshot(const BookSnapshot& snapshot)
+{
+    MarketDataMessage message;
+    message.type = MarketDataMessageType::BookSnapshot;
+    message.snapshot = snapshot;
+    publish(message);
+}
+
+template <std::size_t QueueCapacity>
+void MarketDataFeed<QueueCapacity>::publishTrade(const Trade& trade)
+{
+    MarketDataMessage message;
+    message.type = MarketDataMessageType::Trade;
+    message.trade = trade;
+    publish(message);
+}
+
+template <std::size_t QueueCapacity>
+void MarketDataFeed<QueueCapacity>::publish(const MarketDataMessage& message)
+{
+    std::scoped_lock lock{subscribers_mutex_};
+    for (const auto& subscriber : subscribers_)
+    {
+        if (!subscriber->active.load(std::memory_order_acquire) ||
+            subscriber->instrument_id != message.instrument_id())
+        {
+            continue;
+        }
+        try
+        {
+            subscriber->queue.push(message);
+        }
+        catch (const std::runtime_error&)
+        {
+            // A subscription may close after the active check while another
+            // thread is publishing. Dropping that closed-subscriber copy keeps
+            // unsubscribe idempotent without affecting other subscribers.
+        }
+    }
+}
+
+} // namespace cmf

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -23,6 +23,7 @@ target_link_libraries(${TARGET} PRIVATE
     Catch2-static-lib
     Threads::Threads
     back-tester-ingestion
+    back-tester-market-data-feed
     back-tester-order-book
 )
 

--- a/test/MarketDataFeedTest.cpp
+++ b/test/MarketDataFeedTest.cpp
@@ -1,0 +1,98 @@
+#include "catch2/catch_all.hpp"
+#include "market_data_feed/MarketDataFeed.hpp"
+
+#include <vector>
+
+using namespace cmf;
+
+TEST_CASE("MarketDataFeed routes updates by instrument", "[MarketDataFeed]")
+{
+    MarketDataFeed<> feed;
+    std::vector<MarketDataMessage> first;
+    std::vector<MarketDataMessage> second;
+
+    auto sub1 = feed.subscribe(10, [&](const MarketDataMessage& message,
+                                       [[maybe_unused]] const FeedStatus& status)
+                               { first.push_back(message); });
+    auto sub2 = feed.subscribe(20, [&](const MarketDataMessage& message,
+                                       [[maybe_unused]] const FeedStatus& status)
+                               { second.push_back(message); });
+
+    feed.publishUpdate(BookUpdate{.instrument_id = 10,
+                                  .timestamp_ns = 100,
+                                  .seq_no = 1,
+                                  .side = Side::Buy,
+                                  .price = 123'000'000'000,
+                                  .size = 50});
+
+    REQUIRE(sub1.drain() == 1);
+    REQUIRE(sub2.drain() == 0);
+    REQUIRE(first.size() == 1);
+    REQUIRE(second.empty());
+    REQUIRE(first.front().type == MarketDataMessageType::BookUpdate);
+    REQUIRE(first.front().update.price == 123'000'000'000);
+}
+
+TEST_CASE("MarketDataFeed preserves snapshot and trade payloads",
+          "[MarketDataFeed]")
+{
+    MarketDataFeed<> feed;
+    std::vector<MarketDataMessage> messages;
+    auto sub = feed.subscribe(42, [&](const MarketDataMessage& message,
+                                      [[maybe_unused]] const FeedStatus& status)
+                              { messages.push_back(message); });
+
+    BookSnapshot snapshot;
+    snapshot.instrument_id = 42;
+    snapshot.timestamp_ns = 200;
+    snapshot.seq_no = 1;
+    snapshot.levels.push_back(
+        BookLevel{.side = Side::Buy, .price = 100'000'000'000, .size = 10});
+    snapshot.levels.push_back(
+        BookLevel{.side = Side::Sell, .price = 101'000'000'000, .size = 12});
+    feed.publishSnapshot(snapshot);
+
+    feed.publishTrade(Trade{.instrument_id = 42,
+                            .timestamp_ns = 300,
+                            .seq_no = 2,
+                            .side = Side::Sell,
+                            .price = 100'500'000'000,
+                            .size = 7});
+
+    REQUIRE(sub.drain() == 2);
+    REQUIRE(messages[0].type == MarketDataMessageType::BookSnapshot);
+    REQUIRE(messages[0].snapshot.levels.size() == 2);
+    REQUIRE(messages[0].snapshot.levels[1].price == 101'000'000'000);
+    REQUIRE(messages[1].type == MarketDataMessageType::Trade);
+    REQUIRE(messages[1].trade.size == 7);
+}
+
+TEST_CASE("MarketDataFeed reports per-instrument sequence gaps",
+          "[MarketDataFeed]")
+{
+    MarketDataFeed<> feed;
+    std::vector<FeedStatus> statuses;
+    auto sub = feed.subscribe(7, [&](const MarketDataMessage&,
+                                     const FeedStatus& status)
+                              { statuses.push_back(status); });
+
+    feed.publishUpdate(BookUpdate{.instrument_id = 7,
+                                  .timestamp_ns = 100,
+                                  .seq_no = 10,
+                                  .side = Side::Buy,
+                                  .price = 10,
+                                  .size = 1});
+    feed.publishUpdate(BookUpdate{.instrument_id = 7,
+                                  .timestamp_ns = 101,
+                                  .seq_no = 12,
+                                  .side = Side::Buy,
+                                  .price = 11,
+                                  .size = 2});
+
+    REQUIRE(sub.drain() == 2);
+    REQUIRE(statuses.size() == 2);
+    REQUIRE_FALSE(statuses[0].has_gap);
+    REQUIRE(statuses[1].has_gap);
+    REQUIRE(statuses[1].expected_seq_no == 11);
+    REQUIRE(statuses[1].received_seq_no == 12);
+}


### PR DESCRIPTION
Implements the HW3 Group 2 market data feed on top of `main`.

- Add typed update, snapshot, and trade messages.
- Fan out published messages to per-instrument subscriptions backed by
  per-subscriber lock-free queues.
- Report per-subscription `seq_no` gaps during drain.
- Add Catch2 coverage for routing, payload preservation, and gap detection.
- Add a Google Benchmark case for 1, 2, 4, and 8 subscribers.
- Add a 20-file raw JSON replay benchmark for parse-only baseline and
  parse+feed fanout performance checks.

Verification:
- `cmake --build build --target back-tester-tests back-tester-benchmarks`
- `./build/bin/test/back-tester-tests "[MarketDataFeed]"`
- `./build/bin/test/back-tester-tests`
- `./build/bin/bench/back-tester-benchmarks --benchmark_filter=MarketDataFeed --benchmark_min_time=0.05s`
- `BENCH_DIR=../perf-data/XEUR-20260409-HJTR7RCAKT BENCH_FILE_LIMIT=20 ./build/bin/bench/back-tester-benchmarks --benchmark_filter='MarketDataFeedReplay'`
- `git diff --check`

Assisted-by: Codex:GPT-5.5
