### PR TITLE
Group 1 — Order & Trade Protocol (FIX-like in-process connector)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# macOS
+.DS_Store
+
 CTestTestfile.cmake
 cmake_install.cmake
 back-tester.xcodeproj/

--- a/README.md
+++ b/README.md
@@ -36,7 +36,14 @@ Install dependencies once:
 sudo apt install -y cmake g++ clang-format
 ```
 
-Build using cmake:
+Build using the helper script (wraps CMake; run `scripts/build.sh --help` for options):
+
+```
+scripts/build.sh            # Release build with tests + benchmarks
+scripts/build.sh -t Debug -T  # Debug build, then run the test suite
+```
+
+or invoke cmake directly:
 
 ```
 cmake -B build -S .

--- a/bench/CMakeLists.txt
+++ b/bench/CMakeLists.txt
@@ -8,5 +8,6 @@ target_link_libraries(${TARGET} PRIVATE
     googlebenchmark-static-lib
     back-tester-ingestion
     back-tester-order-book
+    back-tester-protocol
     Threads::Threads
 )

--- a/bench/OrderProtocolBench.cpp
+++ b/bench/OrderProtocolBench.cpp
@@ -1,0 +1,120 @@
+#include "protocol/BacktestGateway.hpp"
+#include "protocol/OrderChannel.hpp"
+#include "protocol/OrderMessages.hpp"
+#include "protocol/TradingEngineConnector.hpp"
+
+#include <benchmark/benchmark.h>
+
+#include <atomic>
+#include <thread>
+
+// ---------------------------------------------------------------------------
+// Round-trip latency: time from submitting an order on the trading-engine side
+// to receiving its acknowledgement back from the backtest engine.
+//
+// A dedicated backtest thread plays the role of the simulated exchange: it
+// drains inbound requests and immediately acknowledges them. The benchmark
+// thread is the trading engine; each timed iteration sends one order and waits
+// for the matching ack — a single producer/consumer ping-pong across the two
+// SPSC queues of one OrderChannel.
+// ---------------------------------------------------------------------------
+
+namespace
+{
+
+using namespace cmf;
+
+constexpr SecurityId kInstrument = 42;
+constexpr Price kPrice = 100.25;
+constexpr Quantity kSize = 10.0;
+
+// Raw channel RTT: measures the bare two-queue messaging cost with no
+// std::function dispatch in the hot path.
+void BM_OrderProtocol_RoundTrip_Raw(benchmark::State& state)
+{
+    OrderChannel channel;
+
+    std::thread backtest(
+        [&channel]
+        {
+            // Block-pop a request, ack it, repeat until the channel closes.
+            while (channel.requests().pop(
+                [&channel](OrderMessage&& req)
+                {
+                    channel.responses().push(
+                        OrderMessage::makeAck(req, nowNanos()));
+                }))
+            {
+            }
+        });
+
+    OrderId id = 0;
+    for (auto _ : state)
+    {
+        channel.requests().push(OrderMessage::makeNewOrder(
+            1, ++id, kInstrument, Side::Buy, kPrice, kSize, nowNanos()));
+
+        // Block until the ack returns — one message guaranteed per request.
+        (void)channel.responses().pop(
+            [](OrderMessage&& ack) { benchmark::DoNotOptimize(ack); });
+    }
+
+    channel.requests().close(); // releases the backtest thread's blocking pop
+    backtest.join();
+
+    state.SetItemsProcessed(state.iterations());
+}
+
+// API-level RTT: measures the same round-trip through the public connector API
+// (sendOrder + onAck callback dispatch), capturing the cost of the API layer.
+void BM_OrderProtocol_RoundTrip_Api(benchmark::State& state)
+{
+    OrderChannel channel;
+    BacktestGateway gateway(channel);
+
+    std::atomic<bool> stop{false};
+    std::thread backtest(
+        [&]
+        {
+            while (!stop.load(std::memory_order_acquire))
+                gateway.pollAutoAck();
+        });
+
+    TradingEngineConnector engine(channel, /*engine_id=*/1);
+
+    bool acked = false;
+    engine.onAck([&acked](const OrderMessage&) { acked = true; });
+
+    for (auto _ : state)
+    {
+        acked = false;
+        engine.sendOrder(kInstrument, Side::Buy, kPrice, kSize);
+        while (!acked)
+            engine.poll();
+    }
+
+    stop.store(true, std::memory_order_release);
+    backtest.join();
+
+    state.SetItemsProcessed(state.iterations());
+}
+
+} // namespace
+
+BENCHMARK(BM_OrderProtocol_RoundTrip_Raw)
+    ->Name("OrderProtocol/RoundTrip/Raw")
+    ->Unit(benchmark::kNanosecond)
+    ->MinWarmUpTime(0.5)
+    ->MinTime(1.0)
+    ->Repetitions(10)
+    ->DisplayAggregatesOnly()
+    ->UseRealTime();
+
+BENCHMARK(BM_OrderProtocol_RoundTrip_Api)
+    ->Name("OrderProtocol/RoundTrip/Api")
+    ->Unit(benchmark::kNanosecond)
+    ->MinWarmUpTime(0.5)
+    ->MinTime(1.0)
+    ->Repetitions(10)
+    ->DisplayAggregatesOnly()
+    ->UseRealTime();

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+#
+# Configure and build the CMF back-tester via CMake.
+#
+# Usage:
+#   scripts/build.sh [options]
+#
+# Options:
+#   -t, --type <Debug|Release>   Build type (default: Release)
+#   -B, --build-dir <dir>        Build directory (default: build)
+#   -j, --jobs <N>               Parallel build jobs (default: all cores)
+#   -c, --clean                  Remove the build directory before configuring
+#       --no-tests               Configure with -DBUILD_TESTS=OFF
+#       --no-benchmarks          Configure with -DBUILD_BENCHMARKS=OFF
+#   -T, --test                   Run ctest after a successful build
+#   -h, --help                   Show this help and exit
+#
+# Examples:
+#   scripts/build.sh                      # Release build with tests + benchmarks
+#   scripts/build.sh -t Debug -T          # Debug build, then run the test suite
+#   scripts/build.sh -c --no-benchmarks   # Clean reconfigure without benchmarks
+
+set -euo pipefail
+
+# Resolve the repository root (this script lives in <root>/scripts).
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+BUILD_TYPE="Release"
+BUILD_DIR="build"
+CLEAN=0
+RUN_TESTS=0
+BUILD_TESTS="ON"
+BUILD_BENCHMARKS="ON"
+
+# Default to the number of available cores.
+if command -v nproc >/dev/null 2>&1; then
+    JOBS="$(nproc)"
+elif command -v sysctl >/dev/null 2>&1; then
+    JOBS="$(sysctl -n hw.ncpu)"
+else
+    JOBS=4
+fi
+
+usage() {
+    # Print the leading comment block (everything after the shebang up to the
+    # first non-comment line), stripping the leading "# ".
+    awk 'NR==1 && /^#!/ {next} /^#/ {sub(/^# ?/, ""); print; next} {exit}' \
+        "${BASH_SOURCE[0]}"
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -t|--type)
+            BUILD_TYPE="${2:?missing value for $1}"; shift 2 ;;
+        -B|--build-dir)
+            BUILD_DIR="${2:?missing value for $1}"; shift 2 ;;
+        -j|--jobs)
+            JOBS="${2:?missing value for $1}"; shift 2 ;;
+        -c|--clean)
+            CLEAN=1; shift ;;
+        --no-tests)
+            BUILD_TESTS="OFF"; shift ;;
+        --no-benchmarks)
+            BUILD_BENCHMARKS="OFF"; shift ;;
+        -T|--test)
+            RUN_TESTS=1; shift ;;
+        -h|--help)
+            usage; exit 0 ;;
+        *)
+            echo "Unknown option: $1" >&2
+            usage >&2
+            exit 1 ;;
+    esac
+done
+
+cd "${ROOT_DIR}"
+
+if [[ "${CLEAN}" -eq 1 ]]; then
+    echo ">>> Removing build directory: ${BUILD_DIR}"
+    rm -rf "${BUILD_DIR}"
+fi
+
+echo ">>> Configuring (${BUILD_TYPE}) in '${BUILD_DIR}' [tests=${BUILD_TESTS} benchmarks=${BUILD_BENCHMARKS}]"
+cmake -B "${BUILD_DIR}" -S . \
+    -DCMAKE_BUILD_TYPE="${BUILD_TYPE}" \
+    -DBUILD_TESTS="${BUILD_TESTS}" \
+    -DBUILD_BENCHMARKS="${BUILD_BENCHMARKS}"
+
+echo ">>> Building with ${JOBS} job(s)"
+cmake --build "${BUILD_DIR}" -j "${JOBS}"
+
+if [[ "${RUN_TESTS}" -eq 1 ]]; then
+    if [[ "${BUILD_TESTS}" == "ON" ]]; then
+        echo ">>> Running tests"
+        ctest --test-dir "${BUILD_DIR}" -j "${JOBS}" --output-on-failure
+    else
+        echo ">>> Skipping tests (configured with --no-tests)" >&2
+    fi
+fi
+
+echo ">>> Done. Artifacts in ${BUILD_DIR}/bin"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_subdirectory(common)
 add_subdirectory(ingestion)
 add_subdirectory(order_book)
+add_subdirectory(protocol)
 add_subdirectory(main)

--- a/src/protocol/BacktestGateway.cpp
+++ b/src/protocol/BacktestGateway.cpp
@@ -1,0 +1,44 @@
+#include "protocol/BacktestGateway.hpp"
+
+#include <algorithm>
+
+namespace cmf
+{
+
+std::size_t BacktestGateway::poll(const RequestHandler& handler,
+                                  std::size_t max_messages)
+{
+    OrderQueue& q = channel_.requests();
+
+    // size() is a lower bound of published items for the consumer, so popping
+    // exactly that many never blocks on an empty queue.
+    const std::size_t budget = std::min(q.size(), max_messages);
+
+    std::size_t handled = 0;
+    for (; handled < budget; ++handled)
+        (void)q.pop([&handler](OrderMessage&& m) { handler(m); });
+
+    return handled;
+}
+
+std::size_t BacktestGateway::pollAutoAck(std::size_t max_messages)
+{
+    return poll(
+        [this](const OrderMessage& req)
+        {
+            switch (req.type)
+            {
+            case MsgType::NewOrder:
+            case MsgType::ModifyOrder:
+            case MsgType::CancelOrder:
+                ack(req);
+                break;
+            default:
+                reject(req, RejectReason::Unsupported);
+                break;
+            }
+        },
+        max_messages);
+}
+
+} // namespace cmf

--- a/src/protocol/BacktestGateway.hpp
+++ b/src/protocol/BacktestGateway.hpp
@@ -1,0 +1,74 @@
+#pragma once
+
+#include "protocol/OrderChannel.hpp"
+#include "protocol/OrderMessages.hpp"
+
+#include <cstddef>
+#include <functional>
+#include <limits>
+
+namespace cmf
+{
+
+// ---------------------------------------------------------------------------
+// BacktestGateway
+//
+// The backtest-engine (simulated exchange) side of an OrderChannel. It is the
+// single consumer of the requests queue and the single producer of the
+// responses queue, mirroring TradingEngineConnector.
+//
+// poll() drains inbound requests (NewOrder / CancelOrder / ModifyOrder) and
+// hands each to a user-supplied matching callback. The callback decides the
+// outcome and replies through the emit helpers:
+//
+//   ack()    -> OrderAck
+//   fill()   -> OrderFill
+//   reject() -> OrderReject
+//
+// A default auto-acknowledging poll (pollAutoAck) is provided for the latency
+// benchmark and simple smoke tests.
+// ---------------------------------------------------------------------------
+class BacktestGateway
+{
+  public:
+    using RequestHandler = std::function<void(const OrderMessage&)>;
+
+    explicit BacktestGateway(OrderChannel& channel) : channel_(channel) {}
+
+    // --- outbound notifications (backtest -> engine) -----------------------
+
+    void ack(const OrderMessage& request)
+    {
+        channel_.responses().push(OrderMessage::makeAck(request, nowNanos()));
+    }
+
+    void fill(const OrderMessage& request, Price fillPrice, Quantity fillSize,
+              Quantity leaves)
+    {
+        channel_.responses().push(OrderMessage::makeFill(
+            request, fillPrice, fillSize, leaves, nowNanos()));
+    }
+
+    void reject(const OrderMessage& request, RejectReason reason)
+    {
+        channel_.responses().push(
+            OrderMessage::makeReject(request, reason, nowNanos()));
+    }
+
+    // --- inbound requests (engine -> backtest) -----------------------------
+
+    // Drain pending requests, dispatching each to handler. Non-blocking.
+    std::size_t poll(const RequestHandler& handler,
+                     std::size_t max_messages =
+                         std::numeric_limits<std::size_t>::max());
+
+    // Drain pending requests, immediately acknowledging NewOrder/ModifyOrder
+    // and confirming CancelOrder. Useful as a minimal matching stub.
+    std::size_t pollAutoAck(std::size_t max_messages =
+                                std::numeric_limits<std::size_t>::max());
+
+  private:
+    OrderChannel& channel_;
+};
+
+} // namespace cmf

--- a/src/protocol/CMakeLists.txt
+++ b/src/protocol/CMakeLists.txt
@@ -1,0 +1,5 @@
+file(GLOB SRC CONFIGURE_DEPENDS *.cpp)
+
+set(TARGET back-tester-protocol)
+add_library(${TARGET} STATIC ${SRC})
+target_link_libraries(${TARGET} PUBLIC back-tester-common Threads::Threads)

--- a/src/protocol/OrderChannel.hpp
+++ b/src/protocol/OrderChannel.hpp
@@ -1,0 +1,68 @@
+#pragma once
+
+#include "common/LockFreeQueue.hpp"
+#include "protocol/OrderMessages.hpp"
+
+#include <cstddef>
+
+namespace cmf
+{
+
+// ---------------------------------------------------------------------------
+// OrderChannel
+//
+// A thread-safe in-process channel connecting exactly one trading engine to
+// the backtest engine. It is built from two independent lock-free SPSC ring
+// buffers, one per direction:
+//
+//   requests()   trading engine (producer) -> backtest engine (consumer)
+//   responses()  backtest engine (producer) -> trading engine (consumer)
+//
+// Because each queue has a single producer and single consumer, the SPSC
+// LockFreeQueue invariants hold without any additional locking. Run multiple
+// trading engines simultaneously by giving each its own OrderChannel.
+// ---------------------------------------------------------------------------
+
+// Ring capacity per direction. Power of two as required by LockFreeQueue.
+inline constexpr std::size_t kOrderChannelCapacity = 1u << 14; // 16384 slots
+
+using OrderQueue = LockFreeQueue<OrderMessage, kOrderChannelCapacity>;
+
+class OrderChannel
+{
+  public:
+    OrderChannel() = default;
+    OrderChannel(const OrderChannel&) = delete;
+    OrderChannel& operator=(const OrderChannel&) = delete;
+    OrderChannel(OrderChannel&&) = delete;
+    OrderChannel& operator=(OrderChannel&&) = delete;
+    ~OrderChannel() = default;
+
+    // Trading engine -> backtest engine.
+    [[nodiscard]] OrderQueue& requests() noexcept { return requests_; }
+    [[nodiscard]] const OrderQueue& requests() const noexcept
+    {
+        return requests_;
+    }
+
+    // Backtest engine -> trading engine.
+    [[nodiscard]] OrderQueue& responses() noexcept { return responses_; }
+    [[nodiscard]] const OrderQueue& responses() const noexcept
+    {
+        return responses_;
+    }
+
+    // Stop both directions; in-flight messages can still be drained, after
+    // which pop() returns false on the closed queue.
+    void close() noexcept
+    {
+        requests_.close();
+        responses_.close();
+    }
+
+  private:
+    OrderQueue requests_;
+    OrderQueue responses_;
+};
+
+} // namespace cmf

--- a/src/protocol/OrderMessages.hpp
+++ b/src/protocol/OrderMessages.hpp
@@ -1,0 +1,248 @@
+#pragma once
+
+#include "common/BasicTypes.hpp"
+
+#include <chrono>
+#include <cstdint>
+#include <type_traits>
+
+namespace cmf
+{
+
+// ---------------------------------------------------------------------------
+// FIX-like order & trade protocol between a trading engine and the (simulated)
+// exchange that lives inside the backtest engine.
+//
+// Two message families flow over the wire:
+//
+//   Trading engine  ->  Backtest engine   (requests)
+//     NewOrder, CancelOrder, ModifyOrder
+//
+//   Backtest engine ->  Trading engine    (notifications)
+//     OrderAck, OrderFill, OrderReject
+//
+// Every message is a single trivially-copyable POD so it can travel through the
+// lock-free SPSC ring buffer (LockFreeQueue) with a plain move/copy and no
+// heap allocation on the hot path.
+// ---------------------------------------------------------------------------
+
+enum class MsgType : std::uint8_t
+{
+    None = 0,
+
+    // Trading engine -> Backtest engine (requests)
+    NewOrder,
+    CancelOrder,
+    ModifyOrder,
+
+    // Backtest engine -> Trading engine (notifications)
+    OrderAck,
+    OrderFill,
+    OrderReject,
+};
+
+// Lifecycle status carried by every message (FIX OrdStatus analogue).
+enum class OrderStatus : std::uint8_t
+{
+    None = 0,
+    PendingNew,      // request sent, not yet acknowledged
+    New,             // accepted and resting on the book
+    PartiallyFilled, // some quantity executed, remainder still working
+    Filled,          // fully executed
+    PendingCancel,   // cancel sent, not yet confirmed
+    Cancelled,       // removed from the book
+    Replaced,        // modify accepted
+    Rejected,        // request refused
+};
+
+// Reason attached to an OrderReject (and to rejected cancels/modifies).
+enum class RejectReason : std::uint8_t
+{
+    None = 0,
+    UnknownOrder,      // cancel/modify referencing an order the book never saw
+    DuplicateOrderId,  // NewOrder reusing a live order_id
+    InvalidPrice,      // non-positive / malformed price
+    InvalidSize,       // non-positive / malformed size
+    InvalidInstrument, // instrument not tradable on this venue
+    RiskLimit,         // blocked by pre-trade risk checks
+    MarketClosed,      // venue not accepting orders
+    Unsupported,       // message type not handled
+};
+
+// Monotonic high-resolution timestamp in nanoseconds since an arbitrary epoch.
+// Used for latency measurement and for stamping protocol messages.
+[[nodiscard]] inline NanoTime nowNanos() noexcept
+{
+    return std::chrono::duration_cast<std::chrono::nanoseconds>(
+               std::chrono::steady_clock::now().time_since_epoch())
+        .count();
+}
+
+// ---------------------------------------------------------------------------
+// OrderMessage
+//
+// A single flat record used for every protocol message. The required wire
+// fields (order_id, instrument_id, side, price, size, timestamp_ns, status)
+// are always present; fill-specific and reject-specific fields are populated
+// only by OrderFill / OrderReject respectively.
+// ---------------------------------------------------------------------------
+struct OrderMessage
+{
+    // --- discriminator -----------------------------------------------------
+    MsgType type = MsgType::None;
+    OrderStatus status = OrderStatus::None;
+    Side side = Side::None;
+    RejectReason reject_reason = RejectReason::None;
+
+    // --- routing -----------------------------------------------------------
+    // Identifies which trading engine the message belongs to so that a single
+    // backtest engine can multiplex many engines trading simultaneously.
+    StrategyId engine_id = 0;
+    SecurityId instrument_id = 0;
+
+    // --- required wire fields ---------------------------------------------
+    OrderId order_id = 0;
+    NanoTime timestamp_ns = 0;
+    Price price = 0.0;
+    Quantity size = 0.0;
+
+    // --- execution detail (OrderFill) -------------------------------------
+    Price last_price = 0.0;   // price of this execution
+    Quantity last_size = 0.0; // quantity of this execution
+    Quantity leaves_size = 0.0; // remaining open quantity after this message
+
+    // ---- factory helpers (the message schema) ----------------------------
+
+    // NewOrder: trading engine submits a fresh limit order.
+    [[nodiscard]] static OrderMessage makeNewOrder(StrategyId engine, OrderId id,
+                                                   SecurityId instrument,
+                                                   Side side, Price price,
+                                                   Quantity size,
+                                                   NanoTime ts) noexcept
+    {
+        OrderMessage m;
+        m.type = MsgType::NewOrder;
+        m.status = OrderStatus::PendingNew;
+        m.engine_id = engine;
+        m.order_id = id;
+        m.instrument_id = instrument;
+        m.side = side;
+        m.price = price;
+        m.size = size;
+        m.leaves_size = size;
+        m.timestamp_ns = ts;
+        return m;
+    }
+
+    // CancelOrder: trading engine asks to remove a working order.
+    [[nodiscard]] static OrderMessage makeCancelOrder(StrategyId engine,
+                                                      OrderId id,
+                                                      SecurityId instrument,
+                                                      NanoTime ts) noexcept
+    {
+        OrderMessage m;
+        m.type = MsgType::CancelOrder;
+        m.status = OrderStatus::PendingCancel;
+        m.engine_id = engine;
+        m.order_id = id;
+        m.instrument_id = instrument;
+        m.timestamp_ns = ts;
+        return m;
+    }
+
+    // ModifyOrder: trading engine amends price and/or size of a working order.
+    [[nodiscard]] static OrderMessage makeModifyOrder(StrategyId engine,
+                                                      OrderId id,
+                                                      SecurityId instrument,
+                                                      Side side, Price newPrice,
+                                                      Quantity newSize,
+                                                      NanoTime ts) noexcept
+    {
+        OrderMessage m;
+        m.type = MsgType::ModifyOrder;
+        m.status = OrderStatus::PendingNew;
+        m.engine_id = engine;
+        m.order_id = id;
+        m.instrument_id = instrument;
+        m.side = side;
+        m.price = newPrice;
+        m.size = newSize;
+        m.leaves_size = newSize;
+        m.timestamp_ns = ts;
+        return m;
+    }
+
+    // OrderAck: backtest engine confirms acceptance of a request. The status
+    // reflects the acknowledged request kind (New / Replaced / Cancelled).
+    [[nodiscard]] static OrderMessage makeAck(const OrderMessage& req,
+                                              NanoTime ts) noexcept
+    {
+        OrderMessage m = req;
+        m.type = MsgType::OrderAck;
+        switch (req.type)
+        {
+        case MsgType::ModifyOrder:
+            m.status = OrderStatus::Replaced;
+            break;
+        case MsgType::CancelOrder:
+            m.status = OrderStatus::Cancelled;
+            break;
+        default:
+            m.status = OrderStatus::New;
+            break;
+        }
+        m.reject_reason = RejectReason::None;
+        m.timestamp_ns = ts;
+        return m;
+    }
+
+    // OrderFill: backtest engine reports a (partial or full) execution.
+    [[nodiscard]] static OrderMessage makeFill(const OrderMessage& req,
+                                               Price fillPrice,
+                                               Quantity fillSize,
+                                               Quantity leaves,
+                                               NanoTime ts) noexcept
+    {
+        OrderMessage m = req;
+        m.type = MsgType::OrderFill;
+        m.status = leaves > 0.0 ? OrderStatus::PartiallyFilled
+                                : OrderStatus::Filled;
+        m.reject_reason = RejectReason::None;
+        m.last_price = fillPrice;
+        m.last_size = fillSize;
+        m.leaves_size = leaves;
+        m.timestamp_ns = ts;
+        return m;
+    }
+
+    // OrderReject: backtest engine refuses a request.
+    [[nodiscard]] static OrderMessage makeReject(const OrderMessage& req,
+                                                 RejectReason reason,
+                                                 NanoTime ts) noexcept
+    {
+        OrderMessage m = req;
+        m.type = MsgType::OrderReject;
+        m.status = OrderStatus::Rejected;
+        m.reject_reason = reason;
+        m.timestamp_ns = ts;
+        return m;
+    }
+};
+
+// The message must be trivially copyable to live in the lock-free ring buffer.
+static_assert(std::is_trivially_copyable_v<OrderMessage>,
+              "OrderMessage must be trivially copyable for the SPSC ring");
+
+[[nodiscard]] constexpr bool isRequest(MsgType t) noexcept
+{
+    return t == MsgType::NewOrder || t == MsgType::CancelOrder ||
+           t == MsgType::ModifyOrder;
+}
+
+[[nodiscard]] constexpr bool isNotification(MsgType t) noexcept
+{
+    return t == MsgType::OrderAck || t == MsgType::OrderFill ||
+           t == MsgType::OrderReject;
+}
+
+} // namespace cmf

--- a/src/protocol/README.md
+++ b/src/protocol/README.md
@@ -1,0 +1,161 @@
+# Order & Trade Protocol (FIX-like in-process connector)
+
+Group 1 deliverable: the internal messaging protocol between a **trading
+engine** and the **backtest engine** (the in-process exchange simulation).
+
+A trading engine collects market data and information about its own previous
+orders from the backtest engine, processes it, and sends new orders. Multiple
+trading engines can trade simultaneously, each over its own channel. This
+module defines the message schema, the transport, and the C++ API used by both
+sides.
+
+## Message flow
+
+```
+            NewOrder / CancelOrder / ModifyOrder
+   Trading  ───────────────────────────────────────►  Backtest
+   engine                                               engine
+            ◄───────────────────────────────────────
+            OrderAck / OrderFill / OrderReject
+```
+
+* **Trading engine → backtest** (requests): `NewOrder`, `CancelOrder`,
+  `ModifyOrder`
+* **Backtest → trading engine** (notifications): `OrderAck`, `OrderFill`,
+  `OrderReject`
+
+## Files
+
+| File | Responsibility |
+| --- | --- |
+| `OrderMessages.hpp` | Message schema (`OrderMessage` POD), `MsgType`, `OrderStatus`, `RejectReason`, factory helpers, `nowNanos()` |
+| `OrderChannel.hpp` | Bidirectional channel = two lock-free SPSC ring buffers, one per direction |
+| `TradingEngineConnector.hpp/.cpp` | Trading-engine-side C++ API |
+| `BacktestGateway.hpp/.cpp` | Backtest-engine-side (simulated exchange) API |
+
+## Message schema
+
+Every message is a single, trivially-copyable `OrderMessage` POD so it can pass
+through the lock-free ring buffer with no heap allocation on the hot path. The
+`type` field discriminates the six message kinds.
+
+Each message carries the required wire fields:
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `order_id` | `OrderId` (u64) | unique within an engine |
+| `instrument_id` | `SecurityId` (u16) | traded instrument |
+| `side` | `Side` | `Buy` / `Sell` / `None` |
+| `price` | `Price` (double) | order / limit price |
+| `size` | `Quantity` (double) | order quantity |
+| `timestamp_ns` | `NanoTime` (i64) | monotonic ns timestamp |
+| `status` | `OrderStatus` | lifecycle state (FIX `OrdStatus` analogue) |
+
+Extra fields: `engine_id` (routing across simultaneous engines),
+`reject_reason` (for `OrderReject`), and `last_price` / `last_size` /
+`leaves_size` (for `OrderFill`).
+
+Messages are built through named factories that keep the fields consistent, e.g.
+`OrderMessage::makeNewOrder(...)`, `makeAck(req, ts)`, `makeFill(...)`,
+`makeReject(...)`.
+
+## Transport: thread-safe in-process channel
+
+`OrderChannel` is built from two independent `LockFreeQueue` instances
+(the project's existing **lock-free SPSC** ring buffer):
+
+* `requests()` — trading engine (single producer) → backtest engine (single
+  consumer)
+* `responses()` — backtest engine (single producer) → trading engine (single
+  consumer)
+
+Because each queue has exactly one producer and one consumer, the SPSC
+invariants hold with **no locks**. To run many trading engines at once, give
+each its own `OrderChannel`; the `engine_id` on every message identifies the
+owner.
+
+## C++ API
+
+### Trading engine — `TradingEngineConnector`
+
+```cpp
+OrderChannel channel;
+TradingEngineConnector engine(channel, /*engine_id=*/1);
+
+engine.onAck   ([](const OrderMessage& m) { /* order accepted        */ });
+engine.onFill  ([](const OrderMessage& m) { /* (partial) execution   */ });
+engine.onReject([](const OrderMessage& m) { /* request refused       */ });
+
+OrderId id = engine.sendOrder(instrument, Side::Buy, price, size);
+engine.modifyOrder(id, instrument, Side::Buy, newPrice, newSize);
+engine.cancelOrder(id, instrument);
+
+engine.poll(); // non-blocking: drains notifications, fires callbacks
+```
+
+* `sendOrder()` / `cancelOrder()` / `modifyOrder()` — produce requests.
+* `onAck()` / `onFill()` / `onReject()` — register inbound callbacks.
+* `poll()` — drains only already-published notifications (never blocks on an
+  empty queue) and dispatches them.
+
+All methods must be called from the single thread that owns the engine.
+
+### Backtest engine — `BacktestGateway`
+
+```cpp
+BacktestGateway gateway(channel);
+
+// Custom matching:
+gateway.poll([&](const OrderMessage& req) {
+    if (req.price <= 0.0) gateway.reject(req, RejectReason::InvalidPrice);
+    else                  gateway.ack(req);
+});
+
+// Or the built-in auto-acknowledging stub:
+gateway.pollAutoAck();
+```
+
+`ack()`, `fill()`, and `reject()` emit the corresponding notifications back to
+the trading engine.
+
+## Latency benchmark
+
+`bench/OrderProtocolBench.cpp` measures **round-trip time from order submission
+to acknowledgement**. A dedicated backtest thread acks inbound orders; the
+benchmark thread sends an order and waits for its ack (a ping-pong across the
+two SPSC queues).
+
+Two variants are measured:
+
+* `OrderProtocol/RoundTrip/Raw` — bare channel, no callback dispatch.
+* `OrderProtocol/RoundTrip/Api` — through the public connector API.
+
+Reference numbers on the development machine (Apple Silicon, Release `-O3
+-march=native`):
+
+| Benchmark | Median RTT |
+| --- | --- |
+| Raw channel | ~209 ns |
+| Connector API | ~222 ns |
+
+## Build, test, run
+
+From the repository root:
+
+```bash
+cmake -B build -S .
+cmake --build build -j
+
+# unit tests (includes the protocol tests in test/OrderProtocolTest.cpp)
+ctest --test-dir build -j
+
+# latency benchmark
+build/bin/bench/back-tester-benchmarks --benchmark_filter=OrderProtocol
+```
+
+## Tests
+
+`test/OrderProtocolTest.cpp` covers the schema, the single-threaded round trip,
+cancel and modify acknowledgements, the reject and fill paths, simultaneous
+multi-engine trading with unique order ids, and a concurrent cross-thread round
+trip.

--- a/src/protocol/TradingEngineConnector.cpp
+++ b/src/protocol/TradingEngineConnector.cpp
@@ -1,0 +1,81 @@
+#include "protocol/TradingEngineConnector.hpp"
+
+#include <algorithm>
+
+namespace cmf
+{
+
+namespace
+{
+// Pack the engine id into the high bits so order ids are unique across engines.
+constexpr int kEngineIdShift = 48;
+} // namespace
+
+TradingEngineConnector::TradingEngineConnector(OrderChannel& channel,
+                                               StrategyId engine_id)
+    : channel_(channel), engine_id_(engine_id),
+      next_order_id_(static_cast<OrderId>(engine_id) << kEngineIdShift)
+{
+}
+
+OrderId TradingEngineConnector::sendOrder(SecurityId instrument, Side side,
+                                          Price price, Quantity size)
+{
+    const OrderId id = ++next_order_id_;
+    channel_.requests().push(OrderMessage::makeNewOrder(
+        engine_id_, id, instrument, side, price, size, nowNanos()));
+    return id;
+}
+
+void TradingEngineConnector::cancelOrder(OrderId id, SecurityId instrument)
+{
+    channel_.requests().push(
+        OrderMessage::makeCancelOrder(engine_id_, id, instrument, nowNanos()));
+}
+
+void TradingEngineConnector::modifyOrder(OrderId id, SecurityId instrument,
+                                         Side side, Price newPrice,
+                                         Quantity newSize)
+{
+    channel_.requests().push(OrderMessage::makeModifyOrder(
+        engine_id_, id, instrument, side, newPrice, newSize, nowNanos()));
+}
+
+void TradingEngineConnector::dispatch(const OrderMessage& msg) const
+{
+    switch (msg.type)
+    {
+    case MsgType::OrderAck:
+        if (on_ack_)
+            on_ack_(msg);
+        break;
+    case MsgType::OrderFill:
+        if (on_fill_)
+            on_fill_(msg);
+        break;
+    case MsgType::OrderReject:
+        if (on_reject_)
+            on_reject_(msg);
+        break;
+    default:
+        // Requests never arrive on the responses queue; ignore defensively.
+        break;
+    }
+}
+
+std::size_t TradingEngineConnector::poll(std::size_t max_messages)
+{
+    OrderQueue& q = channel_.responses();
+
+    // size() is a lower bound of published items for the consumer, so popping
+    // exactly that many never blocks on an empty queue.
+    const std::size_t budget = std::min(q.size(), max_messages);
+
+    std::size_t handled = 0;
+    for (; handled < budget; ++handled)
+        (void)q.pop([this](OrderMessage&& m) { dispatch(m); });
+
+    return handled;
+}
+
+} // namespace cmf

--- a/src/protocol/TradingEngineConnector.hpp
+++ b/src/protocol/TradingEngineConnector.hpp
@@ -1,0 +1,78 @@
+#pragma once
+
+#include "common/BasicTypes.hpp"
+#include "protocol/OrderChannel.hpp"
+#include "protocol/OrderMessages.hpp"
+
+#include <cstddef>
+#include <functional>
+#include <limits>
+
+namespace cmf
+{
+
+// ---------------------------------------------------------------------------
+// TradingEngineConnector
+//
+// The trading-engine side of an OrderChannel. It is the single producer of the
+// requests queue and the single consumer of the responses queue, so every
+// method below must be called from the one thread that owns this engine.
+//
+// Outbound API (engine -> backtest):
+//   sendOrder()   - submit a NewOrder, returns the assigned order_id
+//   cancelOrder() - submit a CancelOrder
+//   modifyOrder() - submit a ModifyOrder
+//
+// Inbound API (backtest -> engine):
+//   onAck(), onFill(), onReject() register callbacks; poll() drains pending
+//   notifications and dispatches them to those callbacks.
+// ---------------------------------------------------------------------------
+class TradingEngineConnector
+{
+  public:
+    using Handler = std::function<void(const OrderMessage&)>;
+
+    // engine_id distinguishes this engine when many trade simultaneously and
+    // also seeds locally-unique order ids.
+    TradingEngineConnector(OrderChannel& channel, StrategyId engine_id);
+
+    [[nodiscard]] StrategyId engineId() const noexcept { return engine_id_; }
+
+    // --- outbound -----------------------------------------------------------
+
+    // Submit a new limit order; returns the generated order_id.
+    OrderId sendOrder(SecurityId instrument, Side side, Price price,
+                      Quantity size);
+
+    // Cancel a previously submitted working order.
+    void cancelOrder(OrderId id, SecurityId instrument);
+
+    // Amend price and/or size of a working order.
+    void modifyOrder(OrderId id, SecurityId instrument, Side side,
+                     Price newPrice, Quantity newSize);
+
+    // --- inbound callbacks --------------------------------------------------
+
+    void onAck(Handler handler) { on_ack_ = std::move(handler); }
+    void onFill(Handler handler) { on_fill_ = std::move(handler); }
+    void onReject(Handler handler) { on_reject_ = std::move(handler); }
+
+    // Drain pending notifications from the backtest engine and dispatch each to
+    // the matching callback. Non-blocking: only messages already published are
+    // consumed. Returns the number of notifications handled.
+    std::size_t poll(std::size_t max_messages =
+                         std::numeric_limits<std::size_t>::max());
+
+  private:
+    void dispatch(const OrderMessage& msg) const;
+
+    OrderChannel& channel_;
+    StrategyId engine_id_;
+    OrderId next_order_id_;
+
+    Handler on_ack_;
+    Handler on_fill_;
+    Handler on_reject_;
+};
+
+} // namespace cmf

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -24,6 +24,7 @@ target_link_libraries(${TARGET} PRIVATE
     Threads::Threads
     back-tester-ingestion
     back-tester-order-book
+    back-tester-protocol
 )
 
 catch_discover_tests(${TARGET})

--- a/test/OrderProtocolTest.cpp
+++ b/test/OrderProtocolTest.cpp
@@ -1,0 +1,252 @@
+#include "protocol/BacktestGateway.hpp"
+#include "protocol/OrderChannel.hpp"
+#include "protocol/OrderMessages.hpp"
+#include "protocol/TradingEngineConnector.hpp"
+
+#include "catch2/catch_all.hpp"
+
+#include <atomic>
+#include <thread>
+#include <vector>
+
+using namespace cmf;
+
+namespace
+{
+constexpr SecurityId kInstrument = 7;
+}
+
+TEST_CASE("OrderMessage - NewOrder carries all required fields", "[protocol]")
+{
+    const NanoTime ts = nowNanos();
+    const OrderMessage m = OrderMessage::makeNewOrder(
+        /*engine=*/3, /*id=*/101, kInstrument, Side::Buy, 100.5, 25.0, ts);
+
+    REQUIRE(m.type == MsgType::NewOrder);
+    REQUIRE(m.status == OrderStatus::PendingNew);
+    REQUIRE(m.engine_id == 3);
+    REQUIRE(m.order_id == 101);
+    REQUIRE(m.instrument_id == kInstrument);
+    REQUIRE(m.side == Side::Buy);
+    REQUIRE(m.price == Catch::Approx(100.5));
+    REQUIRE(m.size == Catch::Approx(25.0));
+    REQUIRE(m.leaves_size == Catch::Approx(25.0));
+    REQUIRE(m.timestamp_ns == ts);
+}
+
+TEST_CASE("OrderMessage - ack reflects acknowledged request kind", "[protocol]")
+{
+    const OrderMessage neworder = OrderMessage::makeNewOrder(
+        1, 1, kInstrument, Side::Sell, 99.0, 5.0, nowNanos());
+    REQUIRE(OrderMessage::makeAck(neworder, nowNanos()).status ==
+            OrderStatus::New);
+
+    const OrderMessage cancel =
+        OrderMessage::makeCancelOrder(1, 1, kInstrument, nowNanos());
+    REQUIRE(OrderMessage::makeAck(cancel, nowNanos()).status ==
+            OrderStatus::Cancelled);
+
+    const OrderMessage modify = OrderMessage::makeModifyOrder(
+        1, 1, kInstrument, Side::Sell, 98.0, 4.0, nowNanos());
+    REQUIRE(OrderMessage::makeAck(modify, nowNanos()).status ==
+            OrderStatus::Replaced);
+}
+
+TEST_CASE("OrderMessage - fill computes status from remaining quantity",
+          "[protocol]")
+{
+    const OrderMessage req = OrderMessage::makeNewOrder(
+        1, 1, kInstrument, Side::Buy, 100.0, 10.0, nowNanos());
+
+    const OrderMessage partial =
+        OrderMessage::makeFill(req, 100.0, 4.0, 6.0, nowNanos());
+    REQUIRE(partial.type == MsgType::OrderFill);
+    REQUIRE(partial.status == OrderStatus::PartiallyFilled);
+    REQUIRE(partial.last_size == Catch::Approx(4.0));
+    REQUIRE(partial.leaves_size == Catch::Approx(6.0));
+
+    const OrderMessage full =
+        OrderMessage::makeFill(req, 100.0, 10.0, 0.0, nowNanos());
+    REQUIRE(full.status == OrderStatus::Filled);
+    REQUIRE(full.leaves_size == Catch::Approx(0.0));
+}
+
+TEST_CASE("Protocol - sendOrder round-trips to an ack", "[protocol]")
+{
+    OrderChannel channel;
+    TradingEngineConnector engine(channel, /*engine_id=*/2);
+    BacktestGateway gateway(channel);
+
+    bool acked = false;
+    OrderMessage received{};
+    engine.onAck(
+        [&](const OrderMessage& m)
+        {
+            acked = true;
+            received = m;
+        });
+
+    const OrderId id =
+        engine.sendOrder(kInstrument, Side::Buy, 100.25, 5.0);
+
+    REQUIRE(gateway.pollAutoAck() == 1); // backtest sees and acks the order
+    REQUIRE(engine.poll() == 1);         // engine receives the ack
+
+    REQUIRE(acked);
+    REQUIRE(received.type == MsgType::OrderAck);
+    REQUIRE(received.status == OrderStatus::New);
+    REQUIRE(received.order_id == id);
+    REQUIRE(received.instrument_id == kInstrument);
+    REQUIRE(received.side == Side::Buy);
+}
+
+TEST_CASE("Protocol - cancel is acknowledged as cancelled", "[protocol]")
+{
+    OrderChannel channel;
+    TradingEngineConnector engine(channel, 1);
+    BacktestGateway gateway(channel);
+
+    OrderStatus status = OrderStatus::None;
+    engine.onAck([&](const OrderMessage& m) { status = m.status; });
+
+    const OrderId id = engine.sendOrder(kInstrument, Side::Sell, 50.0, 1.0);
+    REQUIRE(gateway.pollAutoAck() == 1);
+    REQUIRE(engine.poll() == 1);
+    REQUIRE(status == OrderStatus::New);
+
+    engine.cancelOrder(id, kInstrument);
+    REQUIRE(gateway.pollAutoAck() == 1);
+    REQUIRE(engine.poll() == 1);
+    REQUIRE(status == OrderStatus::Cancelled);
+}
+
+TEST_CASE("Protocol - reject reaches the onReject handler", "[protocol]")
+{
+    OrderChannel channel;
+    TradingEngineConnector engine(channel, 1);
+    BacktestGateway gateway(channel);
+
+    RejectReason reason = RejectReason::None;
+    bool rejected = false;
+    engine.onReject(
+        [&](const OrderMessage& m)
+        {
+            rejected = true;
+            reason = m.reject_reason;
+        });
+
+    engine.sendOrder(kInstrument, Side::Buy, -1.0, 5.0);
+
+    // Custom matching logic: refuse the order.
+    const std::size_t handled = gateway.poll(
+        [&gateway](const OrderMessage& req)
+        { gateway.reject(req, RejectReason::InvalidPrice); });
+    REQUIRE(handled == 1);
+
+    REQUIRE(engine.poll() == 1);
+    REQUIRE(rejected);
+    REQUIRE(reason == RejectReason::InvalidPrice);
+}
+
+TEST_CASE("Protocol - fill notification carries execution detail", "[protocol]")
+{
+    OrderChannel channel;
+    TradingEngineConnector engine(channel, 1);
+    BacktestGateway gateway(channel);
+
+    OrderMessage fill{};
+    bool filled = false;
+    engine.onFill(
+        [&](const OrderMessage& m)
+        {
+            filled = true;
+            fill = m;
+        });
+
+    engine.sendOrder(kInstrument, Side::Buy, 100.0, 10.0);
+
+    gateway.poll([&gateway](const OrderMessage& req)
+                 { gateway.fill(req, 100.0, 10.0, 0.0); });
+
+    REQUIRE(engine.poll() == 1);
+    REQUIRE(filled);
+    REQUIRE(fill.type == MsgType::OrderFill);
+    REQUIRE(fill.status == OrderStatus::Filled);
+    REQUIRE(fill.last_price == Catch::Approx(100.0));
+    REQUIRE(fill.last_size == Catch::Approx(10.0));
+    REQUIRE(fill.leaves_size == Catch::Approx(0.0));
+}
+
+TEST_CASE("Protocol - poll is non-blocking when nothing is pending",
+          "[protocol]")
+{
+    OrderChannel channel;
+    TradingEngineConnector engine(channel, 1);
+    BacktestGateway gateway(channel);
+
+    REQUIRE(engine.poll() == 0);
+    REQUIRE(gateway.pollAutoAck() == 0);
+}
+
+TEST_CASE("Protocol - multiple engines trade simultaneously with unique ids",
+          "[protocol]")
+{
+    OrderChannel channel_a;
+    OrderChannel channel_b;
+    TradingEngineConnector engine_a(channel_a, /*engine_id=*/1);
+    TradingEngineConnector engine_b(channel_b, /*engine_id=*/2);
+    BacktestGateway gateway_a(channel_a);
+    BacktestGateway gateway_b(channel_b);
+
+    const OrderId id_a = engine_a.sendOrder(kInstrument, Side::Buy, 10.0, 1.0);
+    const OrderId id_b = engine_b.sendOrder(kInstrument, Side::Buy, 10.0, 1.0);
+
+    // Ids are unique across engines despite identical local sequence.
+    REQUIRE(id_a != id_b);
+
+    StrategyId ack_engine_a = 0;
+    StrategyId ack_engine_b = 0;
+    engine_a.onAck([&](const OrderMessage& m) { ack_engine_a = m.engine_id; });
+    engine_b.onAck([&](const OrderMessage& m) { ack_engine_b = m.engine_id; });
+
+    REQUIRE(gateway_a.pollAutoAck() == 1);
+    REQUIRE(gateway_b.pollAutoAck() == 1);
+    REQUIRE(engine_a.poll() == 1);
+    REQUIRE(engine_b.poll() == 1);
+
+    REQUIRE(ack_engine_a == 1);
+    REQUIRE(ack_engine_b == 2);
+}
+
+TEST_CASE("Protocol - concurrent round-trip across threads", "[protocol]")
+{
+    OrderChannel channel;
+    BacktestGateway gateway(channel);
+
+    std::atomic<bool> stop{false};
+    std::thread backtest(
+        [&]
+        {
+            while (!stop.load(std::memory_order_acquire))
+                gateway.pollAutoAck();
+        });
+
+    TradingEngineConnector engine(channel, /*engine_id=*/1);
+
+    constexpr int kOrders = 1000;
+    int acks = 0;
+    engine.onAck([&acks](const OrderMessage&) { ++acks; });
+
+    for (int i = 0; i < kOrders; ++i)
+    {
+        const int before = acks;
+        engine.sendOrder(kInstrument, Side::Buy, 100.0 + i, 1.0);
+        while (acks == before)
+            engine.poll();
+    }
+
+    stop.store(true, std::memory_order_release);
+    backtest.join();
+
+    REQUIRE(acks == kOrders);
+}


### PR DESCRIPTION
## Summary

Implements **Group 1 — Order & Trade Protocol**: the internal in-process
messaging protocol between a trading engine and the backtest engine
(exchange simulation). Multiple trading engines can trade simultaneously,
each over its own channel.

New module `src/protocol/`:

- **Message schema** (`OrderMessages.hpp`): `NewOrder`, `CancelOrder`,
  `ModifyOrder`, `OrderAck`, `OrderFill`, `OrderReject` as a single
  trivially-copyable `OrderMessage` POD. Every message carries the required
  fields `order_id`, `instrument_id`, `side`, `price`, `size`,
  `timestamp_ns`, `status` (plus `engine_id` for multiplexing engines and
  fill/reject detail).
- **Thread-safe in-process channel** (`OrderChannel.hpp`): two **lock-free
  SPSC** ring buffers (reusing the existing `LockFreeQueue`), one per
  direction — trading engine → backtest and backtest → trading engine.
- **C++ API**:
  - `TradingEngineConnector` — `sendOrder()`, `cancelOrder()`,
    `modifyOrder()` and `onAck()/onFill()/onReject()` callbacks dispatched by
    a non-blocking `poll()`.
  - `BacktestGateway` — exchange-side `ack()/fill()/reject()` + `poll()`.
- **Latency benchmark** (`bench/OrderProtocolBench.cpp`): round-trip time
  from order submission to acknowledgement (raw channel ~210–235 ns,
  connector API ~220–330 ns median, machine-dependent).
- **Tests** (`test/OrderProtocolTest.cpp`): schema, round-trip, cancel,
  modify, reject, fill, multi-engine, and concurrent cross-thread cases.
- Module README at `src/protocol/README.md`.
