### PR TITLE
HW3 - group 2

### DIFF
--- a/bench/CMakeLists.txt
+++ b/bench/CMakeLists.txt
@@ -8,5 +8,6 @@ target_link_libraries(${TARGET} PRIVATE
     googlebenchmark-static-lib
     back-tester-ingestion
     back-tester-order-book
+    back-tester-feed
     Threads::Threads
 )

--- a/bench/MarketDataFeedAppBench.cpp
+++ b/bench/MarketDataFeedAppBench.cpp
@@ -1,0 +1,199 @@
+#include "common/BlockingQueue.hpp"
+#include "common/MarketDataEvent.hpp"
+#include "feed/FeedMessages.hpp"
+#include "feed/MarketDataPublisher.hpp"
+#include "ingestion/FlatMerger.hpp"
+#include "ingestion/IngestionPipeline.hpp"
+#include "ingestion/JsonNativeDataParser.hpp"
+#include "order_book/AbseilOrderBook.hpp"
+#include "order_book/SimpleOrderBookRouter.hpp"
+#include <benchmark/benchmark.h>
+
+#include <algorithm>
+#include <atomic>
+#include <cstdint>
+#include <cstdlib>
+#include <deque>
+#include <filesystem>
+#include <thread>
+#include <vector>
+
+// Sub-real end-to-end scenario: replay ~20 raw .mbo.json files through the LOB
+// router (previously developed) and feed every resulting book change to the
+// market-data publisher with S subscriber worker threads. Reports pipeline
+// throughput (events/s) and feed fan-out (delivered/s, drops), the same metrics
+// as the micro-benchmarks.
+//
+//   BENCH_DIR    directory holding *.mbo.json files (required)
+//   BENCH_FILES  cap on number of files ingested (optional; default 20)
+namespace
+{
+using Router = cmf::SimpleOrderBookRouter<cmf::AbseilOrderBook>;
+using parser_impl = cmf::JsonNativeDataParser;
+
+cmf::feed::BookSnapshot build_snapshot(const Router& router, uint32_t instr)
+{
+    cmf::feed::BookSnapshot snap{};
+    snap.instrument_id = instr;
+    const auto* book = router.find_book(instr);
+    if (book == nullptr)
+        return snap;
+
+    const auto bids = book->side_levels(cmf::Side::Buy);
+    const std::size_t nb = std::min(bids.size(), cmf::feed::kSnapshotDepth);
+    for (std::size_t i = 0; i < nb; ++i)
+        snap.bids[i] = {bids[i].first, static_cast<uint64_t>(bids[i].second)};
+    snap.bid_depth = static_cast<uint16_t>(nb);
+
+    const auto asks = book->side_levels(cmf::Side::Sell);
+    const std::size_t na = std::min(asks.size(), cmf::feed::kSnapshotDepth);
+    for (std::size_t i = 0; i < na; ++i)
+        snap.asks[i] = {asks[i].first, static_cast<uint64_t>(asks[i].second)};
+    snap.ask_depth = static_cast<uint16_t>(na);
+    return snap;
+}
+
+void publish_feed(Router& router, cmf::feed::MarketDataPublisher& pub,
+                  const cmf::MarketDataEvent& e)
+{
+    const uint32_t instr = router.resolved_instrument(e);
+    if (instr == 0)
+        return;
+    switch (e.action)
+    {
+    case cmf::Action::Add:
+    case cmf::Action::Modify:
+    case cmf::Action::Cancel:
+    {
+        if (e.side == cmf::Side::None || !e.is_price_defined())
+            break;
+        const auto* book = router.find_book(instr);
+        const uint64_t new_qty = book ? book->volume_at(e.side, e.price) : 0;
+        pub.publishUpdate(
+            {0, e.ts_event, instr, e.side, e.price, new_qty});
+        break;
+    }
+    case cmf::Action::Trade:
+    case cmf::Action::Fill:
+        pub.publishTrade({0, e.ts_event, instr, e.side, e.price, e.size});
+        break;
+    case cmf::Action::Clear:
+    {
+        cmf::feed::BookSnapshot snap = build_snapshot(router, instr);
+        snap.ts_event = e.ts_event;
+        pub.publishSnapshot(snap);
+        break;
+    }
+    default:
+        break;
+    }
+}
+
+std::vector<std::filesystem::path> gather_files()
+{
+    std::vector<std::filesystem::path> files;
+    const char* dir = std::getenv("BENCH_DIR");
+    if (!dir || !std::filesystem::is_directory(dir))
+        return files;
+    for (const auto& e : std::filesystem::recursive_directory_iterator(dir))
+        if (e.is_regular_file() &&
+            e.path().string().ends_with(parser_impl::filename_ext))
+            files.push_back(e.path());
+    std::sort(files.begin(), files.end());
+
+    std::size_t cap = 20;
+    if (const char* n = std::getenv("BENCH_FILES"))
+        cap = static_cast<std::size_t>(std::atoll(n));
+    if (files.size() > cap)
+        files.resize(cap);
+    return files;
+}
+} // namespace
+
+template <int Subscribers>
+static void BM_FeedApp(benchmark::State& state)
+{
+    const auto files = gather_files();
+    if (files.empty())
+    {
+        state.SkipWithError("BENCH_DIR unset/empty or no .mbo.json files.");
+        return;
+    }
+    const std::size_t N = files.size();
+
+    int64_t events = 0;
+    std::atomic<int64_t> delivered{0};
+    uint64_t dropped = 0;
+
+    for (auto _ : state)
+    {
+        std::deque<cmf::BlockingQueue<cmf::MarketDataEvent>> file_queues(N);
+        cmf::BlockingQueue<cmf::MarketDataEvent> merged_queue;
+        cmf::FlatMerger<cmf::BlockingQueue, cmf::BlockingQueue> merger(
+            file_queues, merged_queue);
+        std::thread merger_thread([&]
+                                  { merger.run_impl(); });
+
+        std::vector<std::thread> producers;
+        producers.reserve(N);
+        for (std::size_t i = 0; i < N; ++i)
+            producers.emplace_back(
+                [&file_queues, &files, i]
+                {
+                    auto push = [&file_queues, i](const cmf::MarketDataEvent& e)
+                    { file_queues[i].push(e); };
+                    cmf::IngestionPipeline<parser_impl, decltype(push)> pipeline(
+                        files[i], push);
+                    pipeline.ingest();
+                    file_queues[i].close();
+                });
+
+        Router router;
+        cmf::feed::MarketDataPublisher pub;
+        std::vector<cmf::feed::SubscriberHandle> subs;
+        for (int s = 0; s < Subscribers; ++s)
+            subs.push_back(pub.subscribe(
+                [&delivered](const cmf::feed::FeedMessage&)
+                { delivered.fetch_add(1, std::memory_order_relaxed); }));
+
+        int64_t count = 0;
+        while (merged_queue.pop(
+            [&](cmf::MarketDataEvent&& e)
+            {
+                ++count;
+                router.apply(e);
+                if constexpr (Subscribers > 0)
+                    publish_feed(router, pub, e);
+            }))
+            ;
+
+        for (auto& t : producers)
+            t.join();
+        merger_thread.join();
+        pub.shutdown(); // drain + join feed workers before counting
+
+        for (const auto& h : subs)
+            dropped += pub.dropped(h);
+        events = count;
+        benchmark::DoNotOptimize(count);
+    }
+
+    state.SetItemsProcessed(state.iterations() * events);
+    state.counters["events"] = static_cast<double>(events);
+    state.counters["feed_delivered_per_s"] = benchmark::Counter(
+        static_cast<double>(delivered.load()), benchmark::Counter::kIsRate);
+    state.counters["feed_dropped"] = static_cast<double>(dropped);
+}
+
+#define REGISTER_FEED_APP(Subs, Label)   \
+    BENCHMARK_TEMPLATE(BM_FeedApp, Subs) \
+        ->Name(Label)                    \
+        ->Unit(benchmark::kMillisecond)  \
+        ->Iterations(1)                  \
+        ->Repetitions(1)                 \
+        ->UseRealTime()
+
+REGISTER_FEED_APP(0, "FeedApp/baseline_no_feed");
+REGISTER_FEED_APP(1, "FeedApp/1_subscriber");
+REGISTER_FEED_APP(4, "FeedApp/4_subscribers");
+REGISTER_FEED_APP(8, "FeedApp/8_subscribers");

--- a/bench/MarketDataFeedBench.cpp
+++ b/bench/MarketDataFeedBench.cpp
@@ -1,0 +1,124 @@
+#include "common/BasicTypes.hpp"
+#include "feed/FeedMessages.hpp"
+#include "feed/MarketDataPublisher.hpp"
+#include <benchmark/benchmark.h>
+
+#include <array>
+#include <atomic>
+#include <cstdint>
+#include <memory>
+#include <unordered_set>
+
+namespace
+{
+
+using cmf::Side;
+using cmf::feed::BookUpdate;
+using cmf::feed::FeedMessage;
+using cmf::feed::MarketDataPublisher;
+
+// One counter per subscriber, each on its own cache line, so the worker threads
+// don't false-share while counting deliveries (keeps the bench measuring the
+// feed, not counter contention).
+struct alignas(64) PaddedCounter
+{
+    std::atomic<int64_t> v{0};
+};
+
+BookUpdate make_update(int64_t i, uint32_t instrument)
+{
+    return BookUpdate{0, i, instrument, Side::Buy, 100, 1};
+}
+
+} // namespace
+
+// Fan-out throughput: one producer (this thread) publishes N updates per
+// iteration; `Subscribers` worker threads (owned by the publisher) drain in
+// parallel.  The timed region covers publish + full delivery to every
+// subscriber.  N is kept below the queue capacity so nothing is dropped and the
+// drain always completes.
+template <int Subscribers>
+static void BM_Feed_Throughput(benchmark::State& state)
+{
+    const int64_t N = state.range(0);
+    constexpr uint32_t kInstr = 1;
+
+    std::array<PaddedCounter, Subscribers> counts;
+    auto pub = std::make_unique<MarketDataPublisher>();
+    for (int s = 0; s < Subscribers; ++s)
+        (void)pub->subscribe(
+            [&counts, s](const FeedMessage&)
+            { counts[s].v.fetch_add(1, std::memory_order_relaxed); },
+            {kInstr});
+
+    for (auto _ : state)
+    {
+        std::array<int64_t, Subscribers> target;
+        for (int s = 0; s < Subscribers; ++s)
+            target[s] = counts[s].v.load(std::memory_order_relaxed) + N;
+
+        for (int64_t i = 0; i < N; ++i)
+            pub->publishUpdate(make_update(i, kInstr));
+
+        // Wait until every subscriber has drained this iteration's batch.
+        for (int s = 0; s < Subscribers; ++s)
+            while (counts[s].v.load(std::memory_order_acquire) < target[s])
+                benchmark::DoNotOptimize(counts[s].v.load());
+    }
+
+    state.SetItemsProcessed(state.iterations() * N * Subscribers);
+    pub->shutdown();
+}
+
+// Cost of the per-message instrument filter: one subscriber whose filter holds
+// `FilterSize` instruments; every published update matches, so all are
+// delivered and the wants() set lookup is on the hot path.
+template <int FilterSize>
+static void BM_Feed_FilterCost(benchmark::State& state)
+{
+    const int64_t N = state.range(0);
+    constexpr uint32_t kInstr = 1; // always present in the filter set
+
+    std::unordered_set<uint32_t> filter;
+    for (int i = 0; i < FilterSize; ++i)
+        filter.insert(static_cast<uint32_t>(i + 1));
+
+    PaddedCounter delivered;
+    auto pub = std::make_unique<MarketDataPublisher>();
+    (void)pub->subscribe(
+        [&delivered](const FeedMessage&)
+        { delivered.v.fetch_add(1, std::memory_order_relaxed); },
+        filter);
+
+    for (auto _ : state)
+    {
+        const int64_t target = delivered.v.load(std::memory_order_relaxed) + N;
+        for (int64_t i = 0; i < N; ++i)
+            pub->publishUpdate(make_update(i, kInstr));
+        while (delivered.v.load(std::memory_order_acquire) < target)
+            benchmark::DoNotOptimize(delivered.v.load());
+    }
+
+    state.SetItemsProcessed(state.iterations() * N);
+    pub->shutdown();
+}
+
+// 1 << 12 = 4096 < kSubscriberQueueCap (8192): the whole batch fits, so no drops
+// and the per-iteration drain always completes.
+#define REGISTER_FEED_BENCH(BenchFn, Param, Label) \
+    BENCHMARK_TEMPLATE(BenchFn, Param)             \
+        ->Name(Label)                              \
+        ->Arg(1 << 12)                             \
+        ->Unit(benchmark::kMicrosecond)            \
+        ->MinWarmUpTime(0.5)                       \
+        ->MinTime(1.0)                             \
+        ->Repetitions(5)                           \
+        ->DisplayAggregatesOnly()                  \
+        ->UseRealTime()
+
+REGISTER_FEED_BENCH(BM_Feed_Throughput, 1, "Feed/Throughput/1_subscriber");
+REGISTER_FEED_BENCH(BM_Feed_Throughput, 2, "Feed/Throughput/2_subscribers");
+REGISTER_FEED_BENCH(BM_Feed_Throughput, 4, "Feed/Throughput/4_subscribers");
+REGISTER_FEED_BENCH(BM_Feed_Throughput, 8, "Feed/Throughput/8_subscribers");
+REGISTER_FEED_BENCH(BM_Feed_FilterCost, 1, "Feed/FilterCost/1_instrument");
+REGISTER_FEED_BENCH(BM_Feed_FilterCost, 10, "Feed/FilterCost/10_instruments");

--- a/bench/MarketDataFeedBench.cpp
+++ b/bench/MarketDataFeedBench.cpp
@@ -17,9 +17,8 @@ using cmf::feed::BookUpdate;
 using cmf::feed::FeedMessage;
 using cmf::feed::MarketDataPublisher;
 
-// One counter per subscriber, each on its own cache line, so the worker threads
-// don't false-share while counting deliveries (keeps the bench measuring the
-// feed, not counter contention).
+// One counter per subscriber, each on its own cache line, so worker threads
+// don't false-share while counting deliveries.
 struct alignas(64) PaddedCounter
 {
     std::atomic<int64_t> v{0};
@@ -32,11 +31,9 @@ BookUpdate make_update(int64_t i, uint32_t instrument)
 
 } // namespace
 
-// Fan-out throughput: one producer (this thread) publishes N updates per
-// iteration; `Subscribers` worker threads (owned by the publisher) drain in
-// parallel.  The timed region covers publish + full delivery to every
-// subscriber.  N is kept below the queue capacity so nothing is dropped and the
-// drain always completes.
+// One producer publishes N updates per iteration; `Subscribers` worker threads
+// drain in parallel. The timed region covers publish + full delivery. N stays
+// below the queue capacity so nothing is dropped and the drain always completes.
 template <int Subscribers>
 static void BM_Feed_Throughput(benchmark::State& state)
 {
@@ -60,7 +57,6 @@ static void BM_Feed_Throughput(benchmark::State& state)
         for (int64_t i = 0; i < N; ++i)
             pub->publishUpdate(make_update(i, kInstr));
 
-        // Wait until every subscriber has drained this iteration's batch.
         for (int s = 0; s < Subscribers; ++s)
             while (counts[s].v.load(std::memory_order_acquire) < target[s])
                 benchmark::DoNotOptimize(counts[s].v.load());
@@ -71,13 +67,12 @@ static void BM_Feed_Throughput(benchmark::State& state)
 }
 
 // Cost of the per-message instrument filter: one subscriber whose filter holds
-// `FilterSize` instruments; every published update matches, so all are
-// delivered and the wants() set lookup is on the hot path.
+// `FilterSize` instruments, every update matching so the wants() lookup is hot.
 template <int FilterSize>
 static void BM_Feed_FilterCost(benchmark::State& state)
 {
     const int64_t N = state.range(0);
-    constexpr uint32_t kInstr = 1; // always present in the filter set
+    constexpr uint32_t kInstr = 1;
 
     std::unordered_set<uint32_t> filter;
     for (int i = 0; i < FilterSize; ++i)
@@ -103,8 +98,7 @@ static void BM_Feed_FilterCost(benchmark::State& state)
     pub->shutdown();
 }
 
-// 1 << 12 = 4096 < kSubscriberQueueCap (8192): the whole batch fits, so no drops
-// and the per-iteration drain always completes.
+// Arg 4096 < kSubscriberQueueCap (8192): the whole batch fits, so no drops.
 #define REGISTER_FEED_BENCH(BenchFn, Param, Label) \
     BENCHMARK_TEMPLATE(BenchFn, Param)             \
         ->Name(Label)                              \

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_subdirectory(common)
 add_subdirectory(ingestion)
 add_subdirectory(order_book)
+add_subdirectory(feed)
 add_subdirectory(main)

--- a/src/feed/CMakeLists.txt
+++ b/src/feed/CMakeLists.txt
@@ -1,0 +1,8 @@
+file(GLOB SRC CONFIGURE_DEPENDS *.cpp)
+
+set(TARGET back-tester-feed)
+add_library(${TARGET} STATIC ${SRC})
+target_link_libraries(${TARGET} PUBLIC
+    back-tester-common
+    Threads::Threads
+)

--- a/src/feed/FeedMessages.hpp
+++ b/src/feed/FeedMessages.hpp
@@ -1,0 +1,170 @@
+#pragma once
+
+#include "common/BasicTypes.hpp"
+
+#include <array>
+#include <cstdint>
+#include <type_traits>
+
+// Market-data feed protocol messages (HW3 Group 2, inbound half).
+//
+// These sit one level above MarketDataEvent: they describe *book-state changes*
+// (deltas, snapshots, trades) that the publisher fans out to trading engines.
+//
+// Hard rule: every message must be a flat POD so it lives directly in a
+// LockFreeQueue ring slot with NO heap allocation on the publish path.  Fixed
+// std::array (never std::vector/std::string) and value semantics everywhere.
+namespace cmf::feed
+{
+
+// Number of price levels carried in a BookSnapshot per side.
+inline constexpr std::size_t kSnapshotDepth = 10;
+
+// One aggregated price level: (price, total resting quantity at that price).
+struct Level
+{
+    ScaledPrice price = 0;
+    uint64_t qty = 0;
+};
+static_assert(std::is_trivially_copyable_v<Level>);
+
+// Incremental update: the aggregated size at one (instrument, side, price)
+// level changed.  new_qty == 0 means the level was removed.
+struct BookUpdate
+{
+    uint64_t seq = 0; // per-instrument monotonic sequence
+    NanoTime ts_event = 0;
+    uint32_t instrument_id = 0;
+    Side side = Side::None;
+    ScaledPrice price = 0;
+    uint64_t new_qty = 0;
+};
+static_assert(std::is_trivially_copyable_v<BookUpdate>);
+
+// Self-contained top-N snapshot for one instrument.  Sent on subscribe and on
+// Clear so a subscriber can (re)bootstrap its local view without prior state.
+struct BookSnapshot
+{
+    uint64_t seq = 0; // seq this snapshot is consistent with; subscriber
+                      // resets its expected-next to seq + 1
+    NanoTime ts_event = 0;
+    uint32_t instrument_id = 0;
+    uint16_t bid_depth = 0;                   // # valid entries in bids[]
+    uint16_t ask_depth = 0;                   // # valid entries in asks[]
+    std::array<Level, kSnapshotDepth> bids{}; // index 0 = best bid (descending)
+    std::array<Level, kSnapshotDepth> asks{}; // index 0 = best ask (ascending)
+};
+static_assert(std::is_trivially_copyable_v<BookSnapshot>);
+
+// A trade executed.
+struct Trade
+{
+    uint64_t seq = 0;
+    NanoTime ts_event = 0;
+    uint32_t instrument_id = 0;
+    Side aggressor = Side::None; // side that took liquidity
+    ScaledPrice price = 0;
+    uint64_t size = 0;
+};
+static_assert(std::is_trivially_copyable_v<Trade>);
+
+enum class FeedMsgType : uint8_t
+{
+    Update = 0,
+    Snapshot = 1,
+    Trade = 2,
+};
+
+// Tagged union (NOT std::variant): a plain trivially-copyable POD so the queue
+// slot is fixed-size with zero heap.  Ordering across types is preserved
+// because all three share one queue.  Consumers dispatch with feed::visit,
+// which is a cheap switch (no std::variant indirection).
+struct FeedMessage
+{
+    FeedMsgType type;
+    union
+    {
+        BookUpdate update;
+        BookSnapshot snapshot;
+        Trade trade;
+    };
+
+    // A union with members that have default member initializers deletes the
+    // implicit default ctor, so we provide one (defaults to an empty Update).
+    // This does NOT affect trivial-copyability (asserted below).
+    FeedMessage() noexcept : type(FeedMsgType::Update), update{} {}
+
+    static FeedMessage make(const BookUpdate& u) noexcept
+    {
+        FeedMessage m;
+        m.type = FeedMsgType::Update;
+        m.update = u;
+        return m;
+    }
+    static FeedMessage make(const BookSnapshot& s) noexcept
+    {
+        FeedMessage m;
+        m.type = FeedMsgType::Snapshot;
+        m.snapshot = s;
+        return m;
+    }
+    static FeedMessage make(const Trade& t) noexcept
+    {
+        FeedMessage m;
+        m.type = FeedMsgType::Trade;
+        m.trade = t;
+        return m;
+    }
+
+    // Instrument id regardless of variant — used for fan-out filtering.
+    [[nodiscard]] uint32_t instrument_id() const noexcept
+    {
+        switch (type)
+        {
+        case FeedMsgType::Update:
+            return update.instrument_id;
+        case FeedMsgType::Snapshot:
+            return snapshot.instrument_id;
+        case FeedMsgType::Trade:
+            return trade.instrument_id;
+        }
+        return 0;
+    }
+
+    [[nodiscard]] uint64_t seq() const noexcept
+    {
+        switch (type)
+        {
+        case FeedMsgType::Update:
+            return update.seq;
+        case FeedMsgType::Snapshot:
+            return snapshot.seq;
+        case FeedMsgType::Trade:
+            return trade.seq;
+        }
+        return 0;
+    }
+};
+
+static_assert(std::is_trivially_copyable_v<FeedMessage>,
+              "FeedMessage must be trivially copyable to live in a "
+              "LockFreeQueue ring slot with no heap allocation");
+
+// Dispatch a FeedMessage to a visitor with one overload per message type.
+// Reads like std::visit at call sites but compiles to a plain switch.
+template <typename Visitor>
+decltype(auto) visit(const FeedMessage& m, Visitor&& v)
+{
+    switch (m.type)
+    {
+    case FeedMsgType::Snapshot:
+        return std::forward<Visitor>(v)(m.snapshot);
+    case FeedMsgType::Trade:
+        return std::forward<Visitor>(v)(m.trade);
+    case FeedMsgType::Update:
+    default:
+        return std::forward<Visitor>(v)(m.update);
+    }
+}
+
+} // namespace cmf::feed

--- a/src/feed/FeedMessages.hpp
+++ b/src/feed/FeedMessages.hpp
@@ -6,67 +6,48 @@
 #include <cstdint>
 #include <type_traits>
 
-// Market-data feed protocol messages (HW3 Group 2, inbound half).
-//
-// These sit one level above MarketDataEvent: they describe *book-state changes*
-// (deltas, snapshots, trades) that the publisher fans out to trading engines.
-//
-// Hard rule: every message must be a flat POD so it lives directly in a
-// LockFreeQueue ring slot with NO heap allocation on the publish path.  Fixed
-// std::array (never std::vector/std::string) and value semantics everywhere.
 namespace cmf::feed
 {
 
-// Number of price levels carried in a BookSnapshot per side.
 inline constexpr std::size_t kSnapshotDepth = 10;
 
-// One aggregated price level: (price, total resting quantity at that price).
 struct Level
 {
     ScaledPrice price = 0;
     uint64_t qty = 0;
 };
-static_assert(std::is_trivially_copyable_v<Level>);
 
-// Incremental update: the aggregated size at one (instrument, side, price)
-// level changed.  new_qty == 0 means the level was removed.
 struct BookUpdate
 {
-    uint64_t seq = 0; // per-instrument monotonic sequence
+    uint64_t seq = 0;
     NanoTime ts_event = 0;
     uint32_t instrument_id = 0;
     Side side = Side::None;
     ScaledPrice price = 0;
-    uint64_t new_qty = 0;
+    uint64_t new_qty = 0; // 0 = level removed
 };
-static_assert(std::is_trivially_copyable_v<BookUpdate>);
 
-// Self-contained top-N snapshot for one instrument.  Sent on subscribe and on
-// Clear so a subscriber can (re)bootstrap its local view without prior state.
+// Top-N snapshot; seq is the sequence it is consistent with.
 struct BookSnapshot
 {
-    uint64_t seq = 0; // seq this snapshot is consistent with; subscriber
-                      // resets its expected-next to seq + 1
+    uint64_t seq = 0;
     NanoTime ts_event = 0;
     uint32_t instrument_id = 0;
-    uint16_t bid_depth = 0;                   // # valid entries in bids[]
-    uint16_t ask_depth = 0;                   // # valid entries in asks[]
-    std::array<Level, kSnapshotDepth> bids{}; // index 0 = best bid (descending)
-    std::array<Level, kSnapshotDepth> asks{}; // index 0 = best ask (ascending)
+    uint16_t bid_depth = 0;
+    uint16_t ask_depth = 0;
+    std::array<Level, kSnapshotDepth> bids{}; // index 0 = best, descending
+    std::array<Level, kSnapshotDepth> asks{}; // index 0 = best, ascending
 };
-static_assert(std::is_trivially_copyable_v<BookSnapshot>);
 
-// A trade executed.
 struct Trade
 {
     uint64_t seq = 0;
     NanoTime ts_event = 0;
     uint32_t instrument_id = 0;
-    Side aggressor = Side::None; // side that took liquidity
+    Side aggressor = Side::None;
     ScaledPrice price = 0;
     uint64_t size = 0;
 };
-static_assert(std::is_trivially_copyable_v<Trade>);
 
 enum class FeedMsgType : uint8_t
 {
@@ -75,10 +56,7 @@ enum class FeedMsgType : uint8_t
     Trade = 2,
 };
 
-// Tagged union (NOT std::variant): a plain trivially-copyable POD so the queue
-// slot is fixed-size with zero heap.  Ordering across types is preserved
-// because all three share one queue.  Consumers dispatch with feed::visit,
-// which is a cheap switch (no std::variant indirection).
+// Trivially-copyable tagged union: a queue slot is fixed-size with no heap.
 struct FeedMessage
 {
     FeedMsgType type;
@@ -89,9 +67,6 @@ struct FeedMessage
         Trade trade;
     };
 
-    // A union with members that have default member initializers deletes the
-    // implicit default ctor, so we provide one (defaults to an empty Update).
-    // This does NOT affect trivial-copyability (asserted below).
     FeedMessage() noexcept : type(FeedMsgType::Update), update{} {}
 
     static FeedMessage make(const BookUpdate& u) noexcept
@@ -116,7 +91,6 @@ struct FeedMessage
         return m;
     }
 
-    // Instrument id regardless of variant — used for fan-out filtering.
     [[nodiscard]] uint32_t instrument_id() const noexcept
     {
         switch (type)
@@ -146,12 +120,8 @@ struct FeedMessage
     }
 };
 
-static_assert(std::is_trivially_copyable_v<FeedMessage>,
-              "FeedMessage must be trivially copyable to live in a "
-              "LockFreeQueue ring slot with no heap allocation");
+static_assert(std::is_trivially_copyable_v<FeedMessage>);
 
-// Dispatch a FeedMessage to a visitor with one overload per message type.
-// Reads like std::visit at call sites but compiles to a plain switch.
 template <typename Visitor>
 decltype(auto) visit(const FeedMessage& m, Visitor&& v)
 {

--- a/src/feed/MarketDataPublisher.cpp
+++ b/src/feed/MarketDataPublisher.cpp
@@ -8,8 +8,6 @@ namespace cmf::feed
 
 MarketDataPublisher::MarketDataPublisher()
 {
-    // Start with an empty (non-null) subscriber vector so the hot path never
-    // sees a null snapshot.
     active_.store(std::make_shared<SubVec>());
 }
 
@@ -24,15 +22,13 @@ MarketDataPublisher::subscribe(Callback cb,
     auto sub =
         std::make_shared<Subscriber>(id, std::move(cb), std::move(instruments));
 
-    // Enqueue bootstrap messages (e.g. a snapshot) BEFORE the subscriber joins
-    // active_, so they precede any live delta in its FIFO queue.
+    // Enqueue bootstrap before the subscriber joins active_, so it precedes any
+    // live delta in the FIFO queue.
     for (const FeedMessage& m : bootstrap)
         enqueue(*sub, m);
 
     std::unique_lock lock(sub_mutex_);
-    const std::shared_ptr<const SubVec> cur = active_.load();
-    auto next =
-        cur ? std::make_shared<SubVec>(*cur) : std::make_shared<SubVec>();
+    auto next = std::make_shared<SubVec>(*active_.load());
     next->push_back(std::move(sub));
     active_.store(std::move(next));
     return SubscriberHandle{id};
@@ -44,8 +40,6 @@ void MarketDataPublisher::unsubscribe(const SubscriberHandle& h)
     {
         std::unique_lock lock(sub_mutex_);
         const std::shared_ptr<const SubVec> cur = active_.load();
-        if (!cur)
-            return;
         auto next = std::make_shared<SubVec>();
         next->reserve(cur->size());
         for (const auto& s : *cur)
@@ -57,19 +51,15 @@ void MarketDataPublisher::unsubscribe(const SubscriberHandle& h)
         }
         active_.store(std::move(next));
     }
-    // Close outside the lock.  Once removed from `active_` no new messages are
-    // enqueued; close() makes the worker's pop() return false so its jthread
-    // exits.  The Subscriber is destroyed (joined) when the last ref drops.
+    // Closing makes the worker's pop() return false; the Subscriber is joined
+    // when the last reference (incl. any in-flight broadcast snapshot) drops.
     if (removed)
         removed->queue.close();
 }
 
 uint64_t MarketDataPublisher::dropped(const SubscriberHandle& h) const
 {
-    const std::shared_ptr<const SubVec> cur = active_.load();
-    if (!cur)
-        return 0;
-    for (const auto& s : *cur)
+    for (const auto& s : *active_.load())
         if (s->id == h.id)
             return s->dropped.load(std::memory_order_relaxed);
     return 0;
@@ -82,11 +72,6 @@ void MarketDataPublisher::shutdown()
         std::unique_lock lock(sub_mutex_);
         cur = active_.exchange(std::make_shared<SubVec>());
     }
-    if (!cur)
-        return;
-    // Close every queue so each worker's pop() returns false and its jthread
-    // exits.  Subscribers are destroyed (and their workers joined) when `cur`
-    // (and any in-flight broadcast snapshot) drops the last reference.
     for (const auto& s : *cur)
         s->queue.close();
 }

--- a/src/feed/MarketDataPublisher.cpp
+++ b/src/feed/MarketDataPublisher.cpp
@@ -17,11 +17,17 @@ MarketDataPublisher::~MarketDataPublisher() { shutdown(); }
 
 SubscriberHandle
 MarketDataPublisher::subscribe(Callback cb,
-                               std::unordered_set<uint32_t> instruments)
+                               std::unordered_set<uint32_t> instruments,
+                               std::vector<FeedMessage> bootstrap)
 {
     const uint64_t id = next_sub_id_.fetch_add(1, std::memory_order_relaxed);
     auto sub =
         std::make_shared<Subscriber>(id, std::move(cb), std::move(instruments));
+
+    // Enqueue bootstrap messages (e.g. a snapshot) BEFORE the subscriber joins
+    // active_, so they precede any live delta in its FIFO queue.
+    for (const FeedMessage& m : bootstrap)
+        enqueue(*sub, m);
 
     std::unique_lock lock(sub_mutex_);
     const std::shared_ptr<const SubVec> cur = active_.load();

--- a/src/feed/MarketDataPublisher.cpp
+++ b/src/feed/MarketDataPublisher.cpp
@@ -1,0 +1,88 @@
+#include "feed/MarketDataPublisher.hpp"
+
+#include <mutex>
+#include <utility>
+
+namespace cmf::feed
+{
+
+MarketDataPublisher::MarketDataPublisher()
+{
+    // Start with an empty (non-null) subscriber vector so the hot path never
+    // sees a null snapshot.
+    active_.store(std::make_shared<SubVec>());
+}
+
+MarketDataPublisher::~MarketDataPublisher() { shutdown(); }
+
+SubscriberHandle
+MarketDataPublisher::subscribe(Callback cb,
+                               std::unordered_set<uint32_t> instruments)
+{
+    const uint64_t id = next_sub_id_.fetch_add(1, std::memory_order_relaxed);
+    auto sub =
+        std::make_shared<Subscriber>(id, std::move(cb), std::move(instruments));
+
+    std::unique_lock lock(sub_mutex_);
+    const std::shared_ptr<const SubVec> cur = active_.load();
+    auto next =
+        cur ? std::make_shared<SubVec>(*cur) : std::make_shared<SubVec>();
+    next->push_back(std::move(sub));
+    active_.store(std::move(next));
+    return SubscriberHandle{id};
+}
+
+void MarketDataPublisher::unsubscribe(const SubscriberHandle& h)
+{
+    std::shared_ptr<Subscriber> removed;
+    {
+        std::unique_lock lock(sub_mutex_);
+        const std::shared_ptr<const SubVec> cur = active_.load();
+        if (!cur)
+            return;
+        auto next = std::make_shared<SubVec>();
+        next->reserve(cur->size());
+        for (const auto& s : *cur)
+        {
+            if (s->id == h.id)
+                removed = s;
+            else
+                next->push_back(s);
+        }
+        active_.store(std::move(next));
+    }
+    // Close outside the lock.  Once removed from `active_` no new messages are
+    // enqueued; close() makes the worker's pop() return false so its jthread
+    // exits.  The Subscriber is destroyed (joined) when the last ref drops.
+    if (removed)
+        removed->queue.close();
+}
+
+uint64_t MarketDataPublisher::dropped(const SubscriberHandle& h) const
+{
+    const std::shared_ptr<const SubVec> cur = active_.load();
+    if (!cur)
+        return 0;
+    for (const auto& s : *cur)
+        if (s->id == h.id)
+            return s->dropped.load(std::memory_order_relaxed);
+    return 0;
+}
+
+void MarketDataPublisher::shutdown()
+{
+    std::shared_ptr<const SubVec> cur;
+    {
+        std::unique_lock lock(sub_mutex_);
+        cur = active_.exchange(std::make_shared<SubVec>());
+    }
+    if (!cur)
+        return;
+    // Close every queue so each worker's pop() returns false and its jthread
+    // exits.  Subscribers are destroyed (and their workers joined) when `cur`
+    // (and any in-flight broadcast snapshot) drops the last reference.
+    for (const auto& s : *cur)
+        s->queue.close();
+}
+
+} // namespace cmf::feed

--- a/src/feed/MarketDataPublisher.hpp
+++ b/src/feed/MarketDataPublisher.hpp
@@ -47,8 +47,16 @@ class MarketDataPublisher
 
     // Register a subscriber.  Empty `instruments` => receive ALL instruments.
     // The callback runs on the subscriber's own worker thread.
+    //
+    // `bootstrap` messages (typically BookSnapshots) are enqueued into the new
+    // subscriber's queue BEFORE it joins the broadcast set, so they arrive
+    // ahead of any live delta -- the snapshot-then-deltas bootstrap pattern.
+    // Because each queue is SPSC, a non-empty `bootstrap` requires calling
+    // subscribe() on the producer thread (or before live publishing begins), so
+    // every push to this queue originates from a single thread.
     [[nodiscard]] SubscriberHandle
-    subscribe(Callback cb, std::unordered_set<uint32_t> instruments = {});
+    subscribe(Callback cb, std::unordered_set<uint32_t> instruments = {},
+              std::vector<FeedMessage> bootstrap = {});
 
     // Stop a subscriber: closes its queue (its worker drains and exits).
     void unsubscribe(const SubscriberHandle& h);

--- a/src/feed/MarketDataPublisher.hpp
+++ b/src/feed/MarketDataPublisher.hpp
@@ -18,25 +18,16 @@
 namespace cmf::feed
 {
 
-// Capacity of each subscriber's SPSC queue (power of two, per LockFreeQueue).
 inline constexpr std::size_t kSubscriberQueueCap = 8192;
 
-// MarketDataPublisher: one producer (the dispatcher thread) fans feed messages
-// out to N subscribers, each draining its own SPSC LockFreeQueue on its own
-// worker thread.  A slow subscriber cannot block a fast one.
+// Fans feed messages out to N subscribers, each draining its own SPSC queue on
+// its own worker thread, so a slow subscriber cannot block a fast one.
 //
-// Threading contract:
-//   - publishUpdate / publishTrade / publishSnapshot are called from a SINGLE
-//     producer thread (the dispatcher).  This is what makes the per-subscriber
-//     SPSC queues and the lock-free seq counters correct.
-//   - subscribe / unsubscribe are rare control-plane operations driven from a
-//     single control thread; they take a write lock and copy-on-write swap the
-//     immutable subscriber vector so the publish hot path never holds a mutex.
-//     They MAY run concurrently with publishing: a broadcast holds its vector
-//     snapshot (shared_ptr) for the duration, so a subscriber removed mid-fanout
-//     stays alive until that snapshot drops, and enqueue() tolerates a queue
-//     closed mid-push (the message is dropped).
-//     (A subscribe() with a non-empty `bootstrap` is the exception -- see below.)
+// Threading: publish*/next_seq run on a single producer thread. subscribe/
+// unsubscribe run on a single control thread and copy-on-write swap an immutable
+// subscriber vector, so they may run concurrently with publishing -- except a
+// subscribe() with a non-empty `bootstrap`, which must run on the producer
+// thread to keep each queue single-producer.
 class MarketDataPublisher
 {
   public:
@@ -48,23 +39,14 @@ class MarketDataPublisher
     MarketDataPublisher(const MarketDataPublisher&) = delete;
     MarketDataPublisher& operator=(const MarketDataPublisher&) = delete;
 
-    // Register a subscriber.  Empty `instruments` => receive ALL instruments.
-    // The callback runs on the subscriber's own worker thread.
-    //
-    // `bootstrap` messages (typically BookSnapshots) are enqueued into the new
-    // subscriber's queue BEFORE it joins the broadcast set, so they arrive
-    // ahead of any live delta -- the snapshot-then-deltas bootstrap pattern.
-    // Because each queue is SPSC, a non-empty `bootstrap` requires calling
-    // subscribe() on the producer thread (or before live publishing begins), so
-    // every push to this queue originates from a single thread.
+    // Empty `instruments` => receive all. `bootstrap` messages are enqueued
+    // before the subscriber joins the broadcast set (snapshot-then-deltas).
     [[nodiscard]] SubscriberHandle
     subscribe(Callback cb, std::unordered_set<uint32_t> instruments = {},
               std::vector<FeedMessage> bootstrap = {});
 
-    // Stop a subscriber: closes its queue (its worker drains and exits).
     void unsubscribe(const SubscriberHandle& h);
 
-    // Publish (hot path).  Each stamps the message's seq before fan-out.
     void publishUpdate(BookUpdate u)
     {
         u.seq = next_seq(u.instrument_id);
@@ -75,17 +57,13 @@ class MarketDataPublisher
         t.seq = next_seq(t.instrument_id);
         broadcast(FeedMessage::make(t));
     }
-    // A snapshot is a fresh start: it carries the seq it is consistent with and
-    // does NOT advance the counter; subscribers reset expected-next to seq + 1.
+    // A snapshot carries the seq it is consistent with and does NOT advance it.
     void publishSnapshot(BookSnapshot s)
     {
         s.seq = current_seq(s.instrument_id);
         broadcast(FeedMessage::make(s));
     }
 
-    // Sequence counters (producer-thread only; see threading contract).
-    // Inline: they sit on the publish hot path.  Lazily create the counter on
-    // first sight of an instrument.
     [[nodiscard]] uint64_t next_seq(uint32_t instrument)
     {
         auto it = seq_.find(instrument);
@@ -101,7 +79,6 @@ class MarketDataPublisher
                    : it->second->v.load(std::memory_order_relaxed);
     }
 
-    // Messages dropped for a subscriber because its queue was full.
     [[nodiscard]] uint64_t dropped(const SubscriberHandle& h) const;
 
     // Idempotent: close every subscriber queue and join all worker threads.
@@ -124,7 +101,6 @@ class MarketDataPublisher
             return filter_all || filter.contains(instr);
         }
 
-        // Drain loop: exits when the queue is closed AND empty.
         void run()
         {
             while (queue.pop([this](FeedMessage&& m)
@@ -138,35 +114,25 @@ class MarketDataPublisher
         Callback callback;
         std::atomic<uint64_t> dropped{0};
         LockFreeQueue<FeedMessage, kSubscriberQueueCap> queue;
-        std::jthread worker; // declared LAST -> destroyed (joined) FIRST
+        std::jthread worker; // last member: joined before queue/callback die
     };
 
     using SubVec = std::vector<std::shared_ptr<Subscriber>>;
 
-    // Per-instrument sequence counter, padded to its own cache line so adjacent
-    // instruments' counters don't false-share.
     struct alignas(64) SeqCounter
     {
         std::atomic<uint64_t> v{0};
     };
 
-    // Hot path: enqueue with non-blocking drop-on-overflow.  Safe because the
-    // queue is SPSC and only this (producer) thread calls size() and push():
-    // the consumer can only FREE slots, so a passed size-check guarantees the
-    // subsequent push() finds room and never spins.
+    // Non-blocking drop-on-overflow. The size check guarantees room, so push()
+    // won't spin; it may still throw if unsubscribe() closed the queue
+    // concurrently -- benign, message dropped.
     void enqueue(Subscriber& s, const FeedMessage& m) const
     {
         if (s.queue.is_closed()) [[unlikely]]
             return;
         if (s.queue.size() < kSubscriberQueueCap - 1)
         {
-            // The size check guarantees room (the consumer only frees slots), so
-            // push() won't spin; it can still throw "queue is closed" if
-            // unsubscribe() closed this queue between the checks above and here.
-            // That race is benign: push() tests closed_ before touching the ring,
-            // so the queue stays consistent, and the Subscriber is kept alive by
-            // the broadcast snapshot's shared_ptr (no use-after-free). The
-            // subscriber is going away, so the message is simply dropped.
             try
             {
                 s.queue.push(m);
@@ -182,21 +148,15 @@ class MarketDataPublisher
     void broadcast(const FeedMessage& m) const
     {
         const std::shared_ptr<const SubVec> snap = active_.load();
-        if (!snap) [[unlikely]]
-            return;
         const uint32_t instr = m.instrument_id();
         for (const auto& s : *snap)
             if (s->wants(instr))
                 enqueue(*s, m);
     }
 
-    // Immutable, atomically-swapped subscriber vector (copy-on-write).
     std::atomic<std::shared_ptr<const SubVec>> active_;
-    std::shared_mutex sub_mutex_; // guards subscribe/unsubscribe writers
+    std::shared_mutex sub_mutex_;
     std::atomic<uint64_t> next_sub_id_{1};
-
-    // Producer-thread-owned (no lock; see threading contract).  unique_ptr keeps
-    // each SeqCounter's address stable across map rehash.
     std::unordered_map<uint32_t, std::unique_ptr<SeqCounter>> seq_;
 };
 

--- a/src/feed/MarketDataPublisher.hpp
+++ b/src/feed/MarketDataPublisher.hpp
@@ -1,0 +1,177 @@
+#pragma once
+
+#include "common/BasicTypes.hpp"
+#include "common/LockFreeQueue.hpp"
+#include "feed/FeedMessages.hpp"
+#include "feed/Subscriber.hpp"
+
+#include <atomic>
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <shared_mutex>
+#include <thread>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+namespace cmf::feed
+{
+
+// Capacity of each subscriber's SPSC queue (power of two, per LockFreeQueue).
+inline constexpr std::size_t kSubscriberQueueCap = 8192;
+
+// MarketDataPublisher: one producer (the dispatcher thread) fans feed messages
+// out to N subscribers, each draining its own SPSC LockFreeQueue on its own
+// worker thread.  A slow subscriber cannot block a fast one.
+//
+// Threading contract:
+//   - publishUpdate / publishTrade / publishSnapshot are called from a SINGLE
+//     producer thread (the dispatcher).  This is what makes the per-subscriber
+//     SPSC queues and the lock-free seq counters correct.
+//   - subscribe / unsubscribe are rare control-plane operations; they take a
+//     write lock and copy-on-write swap the immutable subscriber vector so the
+//     publish hot path never holds a mutex.
+//   - For Phase B, subscribe/unsubscribe are expected to happen before/after
+//     the publish stream, not concurrently with it.
+class MarketDataPublisher
+{
+  public:
+    using Callback = std::function<void(const FeedMessage&)>;
+
+    MarketDataPublisher();
+    ~MarketDataPublisher();
+
+    MarketDataPublisher(const MarketDataPublisher&) = delete;
+    MarketDataPublisher& operator=(const MarketDataPublisher&) = delete;
+
+    // Register a subscriber.  Empty `instruments` => receive ALL instruments.
+    // The callback runs on the subscriber's own worker thread.
+    [[nodiscard]] SubscriberHandle
+    subscribe(Callback cb, std::unordered_set<uint32_t> instruments = {});
+
+    // Stop a subscriber: closes its queue (its worker drains and exits).
+    void unsubscribe(const SubscriberHandle& h);
+
+    // Publish (hot path).  Each stamps the message's seq before fan-out.
+    void publishUpdate(BookUpdate u)
+    {
+        u.seq = next_seq(u.instrument_id);
+        broadcast(FeedMessage::make(u));
+    }
+    void publishTrade(Trade t)
+    {
+        t.seq = next_seq(t.instrument_id);
+        broadcast(FeedMessage::make(t));
+    }
+    // A snapshot is a fresh start: it carries the seq it is consistent with and
+    // does NOT advance the counter; subscribers reset expected-next to seq + 1.
+    void publishSnapshot(BookSnapshot s)
+    {
+        s.seq = current_seq(s.instrument_id);
+        broadcast(FeedMessage::make(s));
+    }
+
+    // Sequence counters (producer-thread only; see threading contract).
+    // Inline: they sit on the publish hot path.  Lazily create the counter on
+    // first sight of an instrument.
+    [[nodiscard]] uint64_t next_seq(uint32_t instrument)
+    {
+        auto it = seq_.find(instrument);
+        if (it == seq_.end())
+            it = seq_.emplace(instrument, std::make_unique<SeqCounter>()).first;
+        return it->second->v.fetch_add(1, std::memory_order_relaxed) + 1;
+    }
+    [[nodiscard]] uint64_t current_seq(uint32_t instrument) const
+    {
+        const auto it = seq_.find(instrument);
+        return it == seq_.end()
+                   ? 0
+                   : it->second->v.load(std::memory_order_relaxed);
+    }
+
+    // Messages dropped for a subscriber because its queue was full.
+    [[nodiscard]] uint64_t dropped(const SubscriberHandle& h) const;
+
+    // Idempotent: close every subscriber queue and join all worker threads.
+    void shutdown();
+
+  private:
+    struct Subscriber
+    {
+        Subscriber(uint64_t id_, Callback cb,
+                   std::unordered_set<uint32_t> instruments)
+            : id(id_), filter(std::move(instruments)),
+              filter_all(filter.empty()), callback(std::move(cb)),
+              worker([this]
+                     { run(); })
+        {
+        }
+
+        [[nodiscard]] bool wants(uint32_t instr) const noexcept
+        {
+            return filter_all || filter.contains(instr);
+        }
+
+        // Drain loop: exits when the queue is closed AND empty.
+        void run()
+        {
+            while (queue.pop([this](FeedMessage&& m)
+                             { callback(m); }))
+                ;
+        }
+
+        uint64_t id;
+        std::unordered_set<uint32_t> filter;
+        bool filter_all;
+        Callback callback;
+        std::atomic<uint64_t> dropped{0};
+        LockFreeQueue<FeedMessage, kSubscriberQueueCap> queue;
+        std::jthread worker; // declared LAST -> destroyed (joined) FIRST
+    };
+
+    using SubVec = std::vector<std::shared_ptr<Subscriber>>;
+
+    // Per-instrument sequence counter, padded to its own cache line so adjacent
+    // instruments' counters don't false-share.
+    struct alignas(64) SeqCounter
+    {
+        std::atomic<uint64_t> v{0};
+    };
+
+    // Hot path: enqueue with non-blocking drop-on-overflow.  Safe because the
+    // queue is SPSC and only this (producer) thread calls size() and push():
+    // the consumer can only FREE slots, so a passed size-check guarantees the
+    // subsequent push() finds room and never spins.
+    void enqueue(Subscriber& s, const FeedMessage& m) const
+    {
+        if (s.queue.is_closed()) [[unlikely]]
+            return;
+        if (s.queue.size() < kSubscriberQueueCap - 1)
+            s.queue.push(m);
+        else
+            s.dropped.fetch_add(1, std::memory_order_relaxed);
+    }
+
+    void broadcast(const FeedMessage& m) const
+    {
+        const std::shared_ptr<const SubVec> snap = active_.load();
+        if (!snap) [[unlikely]]
+            return;
+        const uint32_t instr = m.instrument_id();
+        for (const auto& s : *snap)
+            if (s->wants(instr))
+                enqueue(*s, m);
+    }
+
+    // Immutable, atomically-swapped subscriber vector (copy-on-write).
+    std::atomic<std::shared_ptr<const SubVec>> active_;
+    std::shared_mutex sub_mutex_; // guards subscribe/unsubscribe writers
+    std::atomic<uint64_t> next_sub_id_{1};
+
+    // Producer-thread-owned (no lock; see threading contract).  unique_ptr keeps
+    // each SeqCounter's address stable across map rehash.
+    std::unordered_map<uint32_t, std::unique_ptr<SeqCounter>> seq_;
+};
+
+} // namespace cmf::feed

--- a/src/feed/MarketDataPublisher.hpp
+++ b/src/feed/MarketDataPublisher.hpp
@@ -29,11 +29,14 @@ inline constexpr std::size_t kSubscriberQueueCap = 8192;
 //   - publishUpdate / publishTrade / publishSnapshot are called from a SINGLE
 //     producer thread (the dispatcher).  This is what makes the per-subscriber
 //     SPSC queues and the lock-free seq counters correct.
-//   - subscribe / unsubscribe are rare control-plane operations; they take a
-//     write lock and copy-on-write swap the immutable subscriber vector so the
-//     publish hot path never holds a mutex.
-//   - For Phase B, subscribe/unsubscribe are expected to happen before/after
-//     the publish stream, not concurrently with it.
+//   - subscribe / unsubscribe are rare control-plane operations driven from a
+//     single control thread; they take a write lock and copy-on-write swap the
+//     immutable subscriber vector so the publish hot path never holds a mutex.
+//     They MAY run concurrently with publishing: a broadcast holds its vector
+//     snapshot (shared_ptr) for the duration, so a subscriber removed mid-fanout
+//     stays alive until that snapshot drops, and enqueue() tolerates a queue
+//     closed mid-push (the message is dropped).
+//     (A subscribe() with a non-empty `bootstrap` is the exception -- see below.)
 class MarketDataPublisher
 {
   public:
@@ -156,7 +159,22 @@ class MarketDataPublisher
         if (s.queue.is_closed()) [[unlikely]]
             return;
         if (s.queue.size() < kSubscriberQueueCap - 1)
-            s.queue.push(m);
+        {
+            // The size check guarantees room (the consumer only frees slots), so
+            // push() won't spin; it can still throw "queue is closed" if
+            // unsubscribe() closed this queue between the checks above and here.
+            // That race is benign: push() tests closed_ before touching the ring,
+            // so the queue stays consistent, and the Subscriber is kept alive by
+            // the broadcast snapshot's shared_ptr (no use-after-free). The
+            // subscriber is going away, so the message is simply dropped.
+            try
+            {
+                s.queue.push(m);
+            }
+            catch (const std::runtime_error&)
+            {
+            }
+        }
         else
             s.dropped.fetch_add(1, std::memory_order_relaxed);
     }

--- a/src/feed/Subscriber.hpp
+++ b/src/feed/Subscriber.hpp
@@ -5,9 +5,7 @@
 namespace cmf::feed
 {
 
-// Opaque handle returned by MarketDataPublisher::subscribe().  The trading
-// engine keeps it and passes it back to unsubscribe().  An id of 0 is the
-// "invalid / not subscribed" sentinel.
+// Opaque handle from subscribe(); id 0 means invalid / not subscribed.
 struct SubscriberHandle
 {
     uint64_t id = 0;

--- a/src/feed/Subscriber.hpp
+++ b/src/feed/Subscriber.hpp
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <cstdint>
+
+namespace cmf::feed
+{
+
+// Opaque handle returned by MarketDataPublisher::subscribe().  The trading
+// engine keeps it and passes it back to unsubscribe().  An id of 0 is the
+// "invalid / not subscribed" sentinel.
+struct SubscriberHandle
+{
+    uint64_t id = 0;
+
+    [[nodiscard]] bool valid() const noexcept { return id != 0; }
+    [[nodiscard]] bool operator==(const SubscriberHandle&) const noexcept =
+        default;
+};
+
+} // namespace cmf::feed

--- a/src/main/CMakeLists.txt
+++ b/src/main/CMakeLists.txt
@@ -14,5 +14,6 @@ target_link_libraries(${TARGET} PUBLIC
     back-tester-lib
     back-tester-ingestion
     back-tester-order-book
+    back-tester-feed
     Threads::Threads
 )

--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -170,6 +170,10 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] const char* argv[])
         IngestionPipeline<parser_impl, decltype(push_fn)> pipeline(
             cfg.data_files[i], push_fn);
         pipeline.ingest();
+        // Flush the final partial batch BEFORE closing: BatchPusher::flush()
+        // skips closed queues, so closing first would silently drop the last
+        // (< BatchSize) events of every file.
+        batcher.flush();
         file_queues[i].close(); });
         }
 

--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -16,11 +16,19 @@
 #include <vector>
 
 #include "common/MarketDataEvent.hpp"
+#include "feed/MarketDataPublisher.hpp"
 #include "order_book/AbseilOrderBook.hpp"
 #include "order_book/BookAnomalyLog.hpp"
 #include "order_book/SimpleOrderBookRouter.hpp"
 
+#include <atomic>
+
 #define PROCESS_MARKET_DATA_EVENT_MODE 1 // 1 = COUNT mode, 2 = PRINT mode
+
+// Market-data feed (HW3 Group 2, inbound half): 1 = derive feed messages after
+// each event and publish them to subscribers; 0 = disabled (original behavior,
+// no feed threads, zero overhead).
+#define ENABLE_MARKET_DATA_FEED 1
 
 using namespace cmf;
 
@@ -57,13 +65,26 @@ struct BatchPusher
 
 struct ProcessMarketDataEvent
 {
-    ProcessMarketDataEvent() : counter_(0) {}
+    ProcessMarketDataEvent() : counter_(0)
+    {
+#if ENABLE_MARKET_DATA_FEED
+        // Phase B: a single demo subscriber (all instruments) that just counts
+        // delivered messages, to prove end-to-end fan-out and measure overhead.
+        demo_sub_ = publisher_.subscribe(
+            [this](const feed::FeedMessage&)
+            { feed_count_.fetch_add(1, std::memory_order_relaxed); });
+#endif
+    }
 
     BlockingQueue<std::string> print_queue;
 
     void operator()(const MarketDataEvent& e)
     {
         order_book_router_.apply(e);
+
+#if ENABLE_MARKET_DATA_FEED
+        publish_feed(e);
+#endif
 
 #if PROCESS_MARKET_DATA_EVENT_MODE == 1
         if (e.ts_recv > 0)
@@ -109,9 +130,71 @@ struct ProcessMarketDataEvent
         order_book_router_.print_best_bid_ask(cout);
     }
 
+#if ENABLE_MARKET_DATA_FEED
+    void print_feed_summary() const
+    {
+        std::printf("Feed messages delivered  : %" PRIu64 "\n",
+                    feed_count_.load(std::memory_order_acquire));
+        std::printf("Feed messages dropped    : %" PRIu64 "\n",
+                    publisher_.dropped(demo_sub_));
+    }
+
+    // Close subscriber queues and join worker threads.  Call after the event
+    // stream ends so no publish races a close.
+    void shutdown_feed() { publisher_.shutdown(); }
+#endif
+
   private:
+#if ENABLE_MARKET_DATA_FEED
+    // Derive feed messages from a just-applied event and publish them.  Runs on
+    // the dispatcher thread (single producer), so reading book state is safe.
+    void publish_feed(const MarketDataEvent& e)
+    {
+        const uint32_t instr = order_book_router_.resolved_instrument(e);
+        if (instr == 0)
+            return;
+
+        switch (e.action)
+        {
+        case Action::Add:
+        case Action::Modify:
+        case Action::Cancel:
+        {
+            // A cancel may carry no side / undefined price; skip what we can't
+            // attribute to a single level.
+            if (e.side == Side::None || !e.is_price_defined())
+                break;
+            const auto* book = order_book_router_.find_book(instr);
+            const uint64_t new_qty = book ? book->volume_at(e.side, e.price) : 0;
+            publisher_.publishUpdate(feed::BookUpdate{0, e.ts_event, instr,
+                                                      e.side, e.price, new_qty});
+            break;
+        }
+        case Action::Trade:
+        case Action::Fill:
+            publisher_.publishTrade(
+                feed::Trade{0, e.ts_event, instr, e.side, e.price, e.size});
+            break;
+        case Action::Clear:
+            // Phase C: publish a fresh BookSnapshot here to resync subscribers.
+            break;
+        default:
+            break;
+        }
+    }
+#endif
+
     mutable std::atomic_ullong counter_;
+#if ENABLE_MARKET_DATA_FEED
+    std::atomic_uint64_t feed_count_{0};
+    feed::SubscriberHandle demo_sub_;
+#endif
     cmf::SimpleOrderBookRouter<cmf::AbseilOrderBook> order_book_router_;
+#if ENABLE_MARKET_DATA_FEED
+    // Declared last -> destroyed first, so worker threads are joined while the
+    // counters/router they reference are still alive.
+    feed::MarketDataPublisher publisher_;
+#endif
 };
 
 int main([[maybe_unused]] int argc, [[maybe_unused]] const char* argv[])
@@ -150,6 +233,11 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] const char* argv[])
 
 #if PROCESS_MARKET_DATA_EVENT_MODE == 1
       sink.summary(timer.elapsed_seconds());
+#endif
+
+#if ENABLE_MARKET_DATA_FEED
+      sink.print_feed_summary();
+      sink.shutdown_feed();
 #endif
 
       sink.print_best_bid_ask(std::cout);

--- a/src/main/main.cpp
+++ b/src/main/main.cpp
@@ -6,6 +6,7 @@
 #include "ingestion/FlatMerger.hpp"
 #include "ingestion/IngestionPipeline.hpp"
 
+#include <algorithm>
 #include <cinttypes>
 #include <cstdio>
 #include <deque>
@@ -146,6 +147,35 @@ struct ProcessMarketDataEvent
 
   private:
 #if ENABLE_MARKET_DATA_FEED
+    // Build a top-N BookSnapshot for `instr` from current book state.  Runs on
+    // the dispatcher thread: side_levels() returns a span into the book's shared
+    // mutable cache, so the bid span is fully copied before the ask span is
+    // requested.
+    feed::BookSnapshot build_snapshot(uint32_t instr) const
+    {
+        feed::BookSnapshot snap{};
+        snap.instrument_id = instr;
+        const auto* book = order_book_router_.find_book(instr);
+        if (book == nullptr)
+            return snap;
+
+        const auto bids = book->side_levels(Side::Buy); // descending
+        const std::size_t nb = std::min(bids.size(), feed::kSnapshotDepth);
+        for (std::size_t i = 0; i < nb; ++i)
+            snap.bids[i] = feed::Level{bids[i].first,
+                                       static_cast<uint64_t>(bids[i].second)};
+        snap.bid_depth = static_cast<uint16_t>(nb);
+
+        const auto asks = book->side_levels(Side::Sell); // ascending
+        const std::size_t na = std::min(asks.size(), feed::kSnapshotDepth);
+        for (std::size_t i = 0; i < na; ++i)
+            snap.asks[i] = feed::Level{asks[i].first,
+                                       static_cast<uint64_t>(asks[i].second)};
+        snap.ask_depth = static_cast<uint16_t>(na);
+
+        return snap;
+    }
+
     // Derive feed messages from a just-applied event and publish them.  Runs on
     // the dispatcher thread (single producer), so reading book state is safe.
     void publish_feed(const MarketDataEvent& e)
@@ -176,8 +206,15 @@ struct ProcessMarketDataEvent
                 feed::Trade{0, e.ts_event, instr, e.side, e.price, e.size});
             break;
         case Action::Clear:
-            // Phase C: publish a fresh BookSnapshot here to resync subscribers.
+        {
+            // Book was just cleared: broadcast a fresh snapshot so subscribers
+            // resync (depths are 0 post-clear).  publishSnapshot stamps the seq
+            // it is consistent with and does not advance the counter.
+            feed::BookSnapshot snap = build_snapshot(instr);
+            snap.ts_event = e.ts_event;
+            publisher_.publishSnapshot(snap);
             break;
+        }
         default:
             break;
         }

--- a/src/order_book/SimpleOrderBookRouter.hpp
+++ b/src/order_book/SimpleOrderBookRouter.hpp
@@ -23,6 +23,15 @@ class SimpleOrderBookRouter
     PmrUnorderedMap<uint32_t, BookType> order_books_;
     PmrUnorderedMap<uint64_t, uint32_t> order_to_instrument_;
 
+    // Records any new order_id -> instrument mapping and returns the resolved
+    // id (0 if unknown).  Single source of truth for apply_impl's resolution.
+    uint32_t resolve_for_apply(const MarketDataEvent& e)
+    {
+        if (e.instrument_id != 0 && e.order_id != 0)
+            order_to_instrument_[e.order_id] = e.instrument_id;
+        return order_to_instrument_[e.order_id];
+    }
+
   public:
 #if CMF_HAS_STD_PMR
     explicit SimpleOrderBookRouter(MemoryResource* mr = default_memory_resource())
@@ -35,10 +44,7 @@ class SimpleOrderBookRouter
 
     void apply_impl(const MarketDataEvent& e)
     {
-        if (e.instrument_id != 0 && e.order_id != 0)
-            order_to_instrument_[e.order_id] = e.instrument_id;
-
-        uint32_t instr_id = order_to_instrument_[e.order_id];
+        const uint32_t instr_id = resolve_for_apply(e);
 
         if (instr_id == 0 && e.order_id != 0) [[unlikely]]
         {
@@ -48,6 +54,35 @@ class SimpleOrderBookRouter
         }
 
         order_books_[instr_id].apply(e);
+    }
+
+    // Look up the book for a (resolved) instrument id; nullptr if none exists.
+    // Lets downstream consumers (e.g. the market-data feed) read book state to
+    // build snapshots and delta sizes.
+    [[nodiscard]] const BookType* find_book(uint32_t instrument_id) const
+    {
+        const auto it = order_books_.find(instrument_id);
+        return it == order_books_.end() ? nullptr : &it->second;
+    }
+
+    // Resolve the instrument id an event maps to.  Call AFTER apply(e) so any
+    // new order_id -> instrument mapping is already recorded.  Returns 0 if
+    // unresolved.  Const, non-mutating twin of resolve_for_apply(): cancels and
+    // modifies may carry instrument_id == 0 and rely on the order_id mapping.
+    [[nodiscard]] uint32_t resolved_instrument(const MarketDataEvent& e) const
+    {
+        if (e.instrument_id != 0)
+            return e.instrument_id;
+        const auto it = order_to_instrument_.find(e.order_id);
+        return it == order_to_instrument_.end() ? 0u : it->second;
+    }
+
+    // Invoke fn(uint32_t instrument_id, const BookType& book) for each book.
+    template <typename Fn>
+    void for_each_instrument(Fn&& fn) const
+    {
+        for (const auto& [instrument_id, order_book] : order_books_)
+            fn(instrument_id, order_book);
     }
 
     void print_snapshot_impl(std::ostream& out,

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -24,6 +24,7 @@ target_link_libraries(${TARGET} PRIVATE
     Threads::Threads
     back-tester-ingestion
     back-tester-order-book
+    back-tester-feed
 )
 
 catch_discover_tests(${TARGET})

--- a/test/MarketDataPublisherTest.cpp
+++ b/test/MarketDataPublisherTest.cpp
@@ -205,3 +205,119 @@ TEST_CASE("MarketDataPublisher - unsubscribe stops delivery", "[Feed]")
 
     REQUIRE(count.load() == before);
 }
+
+TEST_CASE("MarketDataPublisher - subscribe mid-stream gets snapshot before "
+          "deltas",
+          "[Feed]")
+{
+    feed::MarketDataPublisher pub;
+    constexpr uint32_t kInstr = 42;
+
+    // Pre-stream: 500 updates advance the seq counter (no subscribers yet).
+    constexpr int kPre = 500;
+    for (int i = 0; i < kPre; ++i)
+        pub.publishUpdate(feed::BookUpdate{0, i, kInstr, Side::Buy, 100,
+                                           static_cast<uint64_t>(i)});
+    REQUIRE(pub.current_seq(kInstr) == kPre);
+
+    // A bootstrap snapshot consistent with the current seq.
+    feed::BookSnapshot snap{};
+    snap.instrument_id = kInstr;
+    snap.seq = pub.current_seq(kInstr); // 500
+    snap.bid_depth = 1;
+    snap.bids[0] = feed::Level{100, 42};
+
+    std::mutex m;
+    std::vector<feed::FeedMessage> got;
+    std::atomic<int> received{0};
+
+    // Single-threaded producer (this thread) => bootstrap + later deltas all
+    // push from one thread, satisfying the SPSC contract.
+    const feed::SubscriberHandle h = pub.subscribe(
+        [&](const feed::FeedMessage& msg)
+        {
+            {
+                std::lock_guard lock(m);
+                got.push_back(msg);
+            }
+            received.fetch_add(1, std::memory_order_release);
+        },
+        {kInstr}, {feed::FeedMessage::make(snap)});
+
+    constexpr int kPost = 10;
+    for (int i = 0; i < kPost; ++i)
+        pub.publishUpdate(feed::BookUpdate{0, 1000 + i, kInstr, Side::Buy, 100,
+                                           static_cast<uint64_t>(1000 + i)});
+
+    REQUIRE(wait_for([&]
+                     { return received.load() >= 1 + kPost; }));
+    REQUIRE(pub.dropped(h) == 0);
+
+    std::lock_guard lock(m);
+    REQUIRE(got.size() == static_cast<std::size_t>(1 + kPost));
+    // Snapshot first, carrying seq 500.
+    REQUIRE(got[0].type == feed::FeedMsgType::Snapshot);
+    REQUIRE(got[0].seq() == static_cast<uint64_t>(kPre));
+    REQUIRE(got[0].snapshot.bid_depth == 1);
+    // Then deltas 501..510, contiguous (resume at snapshot.seq + 1).
+    for (int i = 0; i < kPost; ++i)
+    {
+        REQUIRE(got[static_cast<std::size_t>(1 + i)].type ==
+                feed::FeedMsgType::Update);
+        REQUIRE(got[static_cast<std::size_t>(1 + i)].seq() ==
+                static_cast<uint64_t>(kPre + 1 + i));
+    }
+}
+
+TEST_CASE("MarketDataPublisher - publishSnapshot broadcasts without advancing "
+          "seq",
+          "[Feed]")
+{
+    feed::MarketDataPublisher pub;
+    constexpr uint32_t kInstr = 7;
+
+    std::mutex m;
+    std::vector<feed::FeedMessage> got;
+    std::atomic<int> received{0};
+
+    const feed::SubscriberHandle h = pub.subscribe(
+        [&](const feed::FeedMessage& msg)
+        {
+            {
+                std::lock_guard lock(m);
+                got.push_back(msg);
+            }
+            received.fetch_add(1, std::memory_order_release);
+        },
+        {kInstr});
+
+    for (int i = 0; i < 3; ++i) // seq -> 1, 2, 3
+        pub.publishUpdate(feed::BookUpdate{0, i, kInstr, Side::Sell, 200,
+                                           static_cast<uint64_t>(i)});
+    REQUIRE(pub.current_seq(kInstr) == 3);
+
+    feed::BookSnapshot snap{};
+    snap.instrument_id = kInstr;
+    pub.publishSnapshot(snap);             // stamps seq = current (3)
+    REQUIRE(pub.current_seq(kInstr) == 3); // snapshot does NOT advance the seq
+
+    for (int i = 0; i < 2; ++i) // seq -> 4, 5
+        pub.publishUpdate(feed::BookUpdate{0, 100 + i, kInstr, Side::Sell, 200,
+                                           static_cast<uint64_t>(i)});
+    REQUIRE(pub.current_seq(kInstr) == 5);
+
+    REQUIRE(wait_for([&]
+                     { return received.load() >= 6; })); // 3 + snap + 2
+
+    std::lock_guard lock(m);
+    REQUIRE(got.size() == 6);
+    REQUIRE(got[0].seq() == 1);
+    REQUIRE(got[1].seq() == 2);
+    REQUIRE(got[2].seq() == 3);
+    REQUIRE(got[3].type == feed::FeedMsgType::Snapshot);
+    REQUIRE(got[3].seq() == 3); // consistent with seq 3
+    REQUIRE(got[4].type == feed::FeedMsgType::Update);
+    REQUIRE(got[4].seq() == 4); // deltas resume contiguously
+    REQUIRE(got[5].seq() == 5);
+    REQUIRE(pub.dropped(h) == 0);
+}

--- a/test/MarketDataPublisherTest.cpp
+++ b/test/MarketDataPublisherTest.cpp
@@ -470,3 +470,78 @@ TEST_CASE("MarketDataPublisher - stalled subscriber drops without blocking the "
 
     pub.shutdown();
 }
+
+TEST_CASE("MarketDataPublisher - subscribe/unsubscribe under load", "[Feed]")
+{
+    feed::MarketDataPublisher pub;
+    constexpr uint32_t kInstr = 1;
+
+    // A stable observer that stays subscribed for the whole run. It must keep
+    // receiving messages strictly in order while subscribers churn around it.
+    std::atomic<uint64_t> obs_count{0};
+    std::atomic<uint64_t> obs_last{0};
+    std::atomic<bool> reordered{false}; // a seq <= previous (FIFO violated)
+    std::atomic<bool> gap{false};       // a seq jump (a drop)
+    const feed::SubscriberHandle obs = pub.subscribe(
+        [&](const feed::FeedMessage& msg)
+        {
+            const uint64_t s = msg.seq();
+            const uint64_t prev = obs_last.exchange(s, std::memory_order_relaxed);
+            if (prev != 0)
+            {
+                if (s <= prev)
+                    reordered.store(true, std::memory_order_relaxed);
+                else if (s != prev + 1)
+                    gap.store(true, std::memory_order_relaxed);
+            }
+            obs_count.fetch_add(1, std::memory_order_relaxed);
+        },
+        {kInstr});
+
+    // The SINGLE producer thread (satisfies the per-queue SPSC contract: every
+    // push originates here, since churn subscribers carry no bootstrap).
+    std::atomic<bool> stop{false};
+    std::atomic<uint64_t> published{0};
+    std::thread producer(
+        [&]
+        {
+            for (int64_t i = 0; !stop.load(std::memory_order_acquire); ++i)
+            {
+                pub.publishUpdate(
+                    feed::BookUpdate{0, i, kInstr, Side::Buy, 100, 1});
+                published.fetch_add(1, std::memory_order_relaxed);
+            }
+        });
+
+    // Control thread (this thread): hammer subscribe/unsubscribe concurrently
+    // with the live broadcast. If the COW swap or worker teardown were unsafe,
+    // this would crash, deadlock, or corrupt the observer's stream.
+    constexpr int kCycles = 3000;
+    std::atomic<uint64_t> churn_delivered{0};
+    for (int c = 0; c < kCycles; ++c)
+    {
+        const feed::SubscriberHandle tmp = pub.subscribe(
+            [&](const feed::FeedMessage&)
+            { churn_delivered.fetch_add(1, std::memory_order_relaxed); },
+            {kInstr});
+        pub.unsubscribe(tmp);
+    }
+
+    // Make sure real publishing overlapped the churn before we stop.
+    REQUIRE(wait_for([&]
+                     { return obs_count.load() > 1000; },
+                     std::chrono::seconds(10)));
+    stop.store(true, std::memory_order_release);
+    producer.join();
+
+    REQUIRE(published.load() > 0);
+    REQUIRE(obs_count.load() > 0);
+    // FIFO is never violated, churn or not: delivered seqs strictly increase.
+    REQUIRE_FALSE(reordered.load());
+    // The observer was never removed; if its queue never overflowed it saw every
+    // message with no gaps despite the concurrent subscribe/unsubscribe storm.
+    if (pub.dropped(obs) == 0)
+        REQUIRE_FALSE(gap.load());
+
+    pub.shutdown(); // all churn workers already joined; now join the observer
+}

--- a/test/MarketDataPublisherTest.cpp
+++ b/test/MarketDataPublisherTest.cpp
@@ -1,0 +1,207 @@
+#include "catch2/catch_all.hpp"
+
+#include "common/LockFreeQueue.hpp"
+#include "feed/FeedMessages.hpp"
+#include "feed/MarketDataPublisher.hpp"
+
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <mutex>
+#include <thread>
+#include <vector>
+
+using namespace cmf;
+
+namespace
+{
+// Spin (bounded) until `pred` holds, so async-delivery tests don't hang on
+// failure.  Returns the final value of pred().
+template <typename Pred>
+bool wait_for(Pred pred, std::chrono::milliseconds timeout =
+                             std::chrono::seconds(5))
+{
+    const auto deadline = std::chrono::steady_clock::now() + timeout;
+    while (!pred() && std::chrono::steady_clock::now() < deadline)
+        std::this_thread::yield();
+    return pred();
+}
+} // namespace
+
+TEST_CASE("FeedMessage - trivially copyable and survives queue round-trip",
+          "[Feed]")
+{
+    STATIC_REQUIRE(std::is_trivially_copyable_v<feed::FeedMessage>);
+
+    LockFreeQueue<feed::FeedMessage, 16> q;
+
+    // Update
+    q.push(feed::FeedMessage::make(
+        feed::BookUpdate{7, 1000, 42, Side::Sell, 12345, 99}));
+    // Trade
+    q.push(feed::FeedMessage::make(
+        feed::Trade{8, 1100, 42, Side::Buy, 12350, 5}));
+    // Snapshot
+    feed::BookSnapshot snap{};
+    snap.seq = 9;
+    snap.ts_event = 1200;
+    snap.instrument_id = 42;
+    snap.bid_depth = 2;
+    snap.ask_depth = 1;
+    snap.bids[0] = feed::Level{500, 10};
+    snap.bids[1] = feed::Level{499, 20};
+    snap.asks[0] = feed::Level{501, 15};
+    q.push(feed::FeedMessage::make(snap));
+
+    feed::FeedMessage out;
+
+    REQUIRE(q.pop([&](feed::FeedMessage&& m)
+                  { out = m; }));
+    REQUIRE(out.type == feed::FeedMsgType::Update);
+    REQUIRE(out.update.seq == 7);
+    REQUIRE(out.update.instrument_id == 42);
+    REQUIRE(out.update.side == Side::Sell);
+    REQUIRE(out.update.price == 12345);
+    REQUIRE(out.update.new_qty == 99);
+    REQUIRE(out.instrument_id() == 42);
+    REQUIRE(out.seq() == 7);
+
+    REQUIRE(q.pop([&](feed::FeedMessage&& m)
+                  { out = m; }));
+    REQUIRE(out.type == feed::FeedMsgType::Trade);
+    REQUIRE(out.trade.aggressor == Side::Buy);
+    REQUIRE(out.trade.price == 12350);
+    REQUIRE(out.trade.size == 5);
+
+    REQUIRE(q.pop([&](feed::FeedMessage&& m)
+                  { out = m; }));
+    REQUIRE(out.type == feed::FeedMsgType::Snapshot);
+    REQUIRE(out.snapshot.bid_depth == 2);
+    REQUIRE(out.snapshot.ask_depth == 1);
+    REQUIRE(out.snapshot.bids[0].price == 500);
+    REQUIRE(out.snapshot.bids[1].qty == 20);
+    REQUIRE(out.snapshot.asks[0].price == 501);
+}
+
+TEST_CASE("FeedMessage - visit dispatches to the matching overload", "[Feed]")
+{
+    auto type_of = [](const feed::FeedMessage& m)
+    {
+        return feed::visit(
+            m, [](const auto& x) -> feed::FeedMsgType
+            {
+                   using T = std::decay_t<decltype(x)>;
+                   if constexpr (std::is_same_v<T, feed::BookUpdate>)
+                       return feed::FeedMsgType::Update;
+                   else if constexpr (std::is_same_v<T, feed::Trade>)
+                       return feed::FeedMsgType::Trade;
+                   else
+                       return feed::FeedMsgType::Snapshot; });
+    };
+
+    REQUIRE(type_of(feed::FeedMessage::make(feed::BookUpdate{})) ==
+            feed::FeedMsgType::Update);
+    REQUIRE(type_of(feed::FeedMessage::make(feed::Trade{})) ==
+            feed::FeedMsgType::Trade);
+    REQUIRE(type_of(feed::FeedMessage::make(feed::BookSnapshot{})) ==
+            feed::FeedMsgType::Snapshot);
+}
+
+TEST_CASE("MarketDataPublisher - per-instrument sequence numbers are "
+          "independent",
+          "[Feed]")
+{
+    feed::MarketDataPublisher pub;
+
+    REQUIRE(pub.current_seq(1) == 0);
+    REQUIRE(pub.next_seq(1) == 1);
+    REQUIRE(pub.next_seq(1) == 2);
+    REQUIRE(pub.next_seq(2) == 1); // independent counter for instrument 2
+    REQUIRE(pub.current_seq(1) == 2);
+    REQUIRE(pub.current_seq(2) == 1);
+}
+
+TEST_CASE("MarketDataPublisher - single subscriber sees contiguous, in-order "
+          "sequence numbers with no drops",
+          "[Feed]")
+{
+    feed::MarketDataPublisher pub;
+
+    std::mutex m;
+    std::vector<uint64_t> seqs;
+    std::atomic<int> received{0};
+
+    const feed::SubscriberHandle h = pub.subscribe(
+        [&](const feed::FeedMessage& msg)
+        {
+            {
+                std::lock_guard lock(m);
+                seqs.push_back(msg.seq());
+            }
+            received.fetch_add(1, std::memory_order_release);
+        });
+
+    // N <= queue capacity - 1 so nothing can be dropped regardless of how the
+    // worker is scheduled (the deterministic "no gap" guarantee).
+    constexpr int N = 4000;
+    for (int i = 0; i < N; ++i)
+        pub.publishUpdate(feed::BookUpdate{0, i, 42, Side::Buy, 100,
+                                           static_cast<uint64_t>(i)});
+
+    REQUIRE(wait_for([&]
+                     { return received.load() >= N; }));
+    REQUIRE(pub.dropped(h) == 0);
+
+    std::lock_guard lock(m);
+    REQUIRE(seqs.size() == static_cast<std::size_t>(N));
+    for (int i = 0; i < N; ++i)
+        REQUIRE(seqs[static_cast<std::size_t>(i)] ==
+                static_cast<uint64_t>(i + 1)); // seq starts at 1, contiguous
+}
+
+TEST_CASE("MarketDataPublisher - clean shutdown joins workers and is idempotent",
+          "[Feed]")
+{
+    feed::MarketDataPublisher pub;
+    std::atomic<int> count{0};
+
+    (void)pub.subscribe([&](const feed::FeedMessage&)
+                        { count.fetch_add(1, std::memory_order_relaxed); });
+
+    constexpr int N = 100;
+    for (int i = 0; i < N; ++i)
+        pub.publishUpdate(feed::BookUpdate{0, i, 1, Side::Buy, 10,
+                                           static_cast<uint64_t>(i)});
+
+    // shutdown() closes queues and joins workers (drains remaining first); must
+    // return without hanging.
+    pub.shutdown();
+    REQUIRE(count.load() == N); // all queued messages delivered before exit
+
+    pub.shutdown(); // idempotent: no hang, no throw
+    SUCCEED("second shutdown returned cleanly");
+}
+
+TEST_CASE("MarketDataPublisher - unsubscribe stops delivery", "[Feed]")
+{
+    feed::MarketDataPublisher pub;
+    std::atomic<int> count{0};
+
+    const feed::SubscriberHandle h = pub.subscribe(
+        [&](const feed::FeedMessage&)
+        { count.fetch_add(1, std::memory_order_relaxed); });
+
+    pub.publishUpdate(feed::BookUpdate{0, 0, 1, Side::Buy, 10, 1});
+    REQUIRE(wait_for([&]
+                     { return count.load() >= 1; }));
+
+    pub.unsubscribe(h);
+
+    // After unsubscribe the subscriber is gone; publishing must not deliver or
+    // crash.
+    const int before = count.load();
+    for (int i = 0; i < 100; ++i)
+        pub.publishUpdate(feed::BookUpdate{0, i, 1, Side::Buy, 10, 1});
+
+    REQUIRE(count.load() == before);
+}

--- a/test/MarketDataPublisherTest.cpp
+++ b/test/MarketDataPublisherTest.cpp
@@ -321,3 +321,152 @@ TEST_CASE("MarketDataPublisher - publishSnapshot broadcasts without advancing "
     REQUIRE(got[5].seq() == 5);
     REQUIRE(pub.dropped(h) == 0);
 }
+
+TEST_CASE("MarketDataPublisher - per-instrument filter delivers only subscribed "
+          "instruments",
+          "[Feed]")
+{
+    feed::MarketDataPublisher pub;
+    constexpr uint32_t kWanted = 10;
+    constexpr uint32_t kOther = 20;
+
+    std::mutex m;
+    std::vector<uint32_t> seen;
+    std::atomic<int> received{0};
+
+    const feed::SubscriberHandle h = pub.subscribe(
+        [&](const feed::FeedMessage& msg)
+        {
+            {
+                std::lock_guard lock(m);
+                seen.push_back(msg.instrument_id());
+            }
+            received.fetch_add(1, std::memory_order_release);
+        },
+        {kWanted}); // filter: only instrument 10
+
+    constexpr int N = 50;
+    for (int i = 0; i < N; ++i) // interleave wanted / other
+    {
+        pub.publishUpdate(feed::BookUpdate{0, i, kWanted, Side::Buy, 100, 1});
+        pub.publishUpdate(feed::BookUpdate{0, i, kOther, Side::Buy, 100, 1});
+    }
+
+    REQUIRE(wait_for([&]
+                     { return received.load() >= N; }));
+    // Filtered-out instruments are never enqueued, so the count settles at N.
+    std::lock_guard lock(m);
+    REQUIRE(seen.size() == static_cast<std::size_t>(N));
+    for (uint32_t id : seen)
+        REQUIRE(id == kWanted);
+    REQUIRE(pub.dropped(h) == 0); // filtering is not a drop
+}
+
+TEST_CASE("MarketDataPublisher - fans out to multiple subscribers independently",
+          "[Feed]")
+{
+    feed::MarketDataPublisher pub;
+    constexpr uint32_t kInstr = 5;
+
+    std::atomic<int> a_count{0};
+    std::atomic<int> b_count{0};
+    std::atomic<uint64_t> a_last{0};
+    std::atomic<uint64_t> b_last{0};
+    std::atomic<bool> a_ok{true};
+    std::atomic<bool> b_ok{true};
+
+    const feed::SubscriberHandle ha = pub.subscribe(
+        [&](const feed::FeedMessage& msg)
+        {
+            const uint64_t s = msg.seq();
+            const uint64_t prev = a_last.exchange(s, std::memory_order_relaxed);
+            if (prev != 0 && s != prev + 1)
+                a_ok.store(false, std::memory_order_relaxed);
+            a_count.fetch_add(1, std::memory_order_relaxed);
+        },
+        {kInstr});
+    const feed::SubscriberHandle hb = pub.subscribe(
+        [&](const feed::FeedMessage& msg)
+        {
+            const uint64_t s = msg.seq();
+            const uint64_t prev = b_last.exchange(s, std::memory_order_relaxed);
+            if (prev != 0 && s != prev + 1)
+                b_ok.store(false, std::memory_order_relaxed);
+            b_count.fetch_add(1, std::memory_order_relaxed);
+        },
+        {kInstr});
+
+    constexpr int N = 2000; // < queue capacity, so no drops for either
+    for (int i = 0; i < N; ++i)
+        pub.publishUpdate(feed::BookUpdate{0, i, kInstr, Side::Buy, 100, 1});
+
+    REQUIRE(wait_for([&]
+                     { return a_count.load() >= N && b_count.load() >= N; }));
+
+    // Both subscribers independently received every message, in order, no drops.
+    REQUIRE(a_count.load() == N);
+    REQUIRE(b_count.load() == N);
+    REQUIRE(a_ok.load());
+    REQUIRE(b_ok.load());
+    REQUIRE(pub.dropped(ha) == 0);
+    REQUIRE(pub.dropped(hb) == 0);
+
+    pub.shutdown(); // join workers before captured atomics go out of scope
+}
+
+TEST_CASE("MarketDataPublisher - stalled subscriber drops without blocking the "
+          "publisher, and the gap is detectable",
+          "[Feed]")
+{
+    feed::MarketDataPublisher pub;
+    constexpr uint32_t kInstr = 1;
+    constexpr int kCap = static_cast<int>(feed::kSubscriberQueueCap);
+
+    std::atomic<bool> blocked{true};
+    std::atomic<uint64_t> count{0};
+    std::atomic<uint64_t> last{0};
+    std::atomic<bool> gap{false};
+
+    const feed::SubscriberHandle h = pub.subscribe(
+        [&](const feed::FeedMessage& msg)
+        {
+            // Stall on the first message until released so the queue overflows.
+            while (blocked.load(std::memory_order_acquire))
+                std::this_thread::sleep_for(std::chrono::milliseconds(1));
+            const uint64_t s = msg.seq();
+            const uint64_t prev = last.exchange(s, std::memory_order_relaxed);
+            if (prev != 0 && s != prev + 1)
+                gap.store(true, std::memory_order_relaxed);
+            count.fetch_add(1, std::memory_order_relaxed);
+        },
+        {kInstr});
+
+    // Phase 1: publish 2x capacity while stalled. The publisher must NOT block;
+    // the excess overflows the subscriber's queue and is dropped.
+    const int n1 = 2 * kCap;
+    for (int i = 0; i < n1; ++i)
+        pub.publishUpdate(feed::BookUpdate{0, i, kInstr, Side::Buy, 100, 1});
+    REQUIRE(pub.dropped(h) > 0); // overflow happened; publish loop didn't hang
+
+    // Release; the subscriber drains the buffered (contiguous) prefix.
+    blocked.store(false, std::memory_order_release);
+    REQUIRE(wait_for([&]
+                     { return count.load() >= static_cast<uint64_t>(kCap - 1); },
+                     std::chrono::seconds(10)));
+
+    // Phase 2: now-draining subscriber has room again; these later seqs land
+    // after the dropped region, so the subscriber observes a gap (seq jump).
+    const uint64_t seq_before = pub.current_seq(kInstr); // == n1
+    const int n2 = 200;
+    for (int i = 0; i < n2; ++i)
+        pub.publishUpdate(feed::BookUpdate{0, i, kInstr, Side::Buy, 100, 1});
+
+    REQUIRE(wait_for(
+        [&]
+        { return last.load() == seq_before + static_cast<uint64_t>(n2); },
+        std::chrono::seconds(10)));
+    REQUIRE(gap.load());         // subscriber detected the loss via seq numbers
+    REQUIRE(pub.dropped(h) > 0); // and the publisher surfaced it as drops
+
+    pub.shutdown();
+}


### PR DESCRIPTION
# HW3 — Group 2 (Market-Data Feed): Implementation Summary

The inbound half of the backtest↔trading protocol: deliver market-data messages
from the backtest engine to one or more trading engines — fast, lossless, with
sequence numbers and snapshots. Implemented in a new `src/feed/` module wired
into the existing pipeline right after the order-book router applies each event.

## New module: `src/feed/`

| File | Purpose |
|---|---|
| `FeedMessages.hpp` | POD message types `BookUpdate`, `BookSnapshot` (fixed `std::array<Level,N>`, N=10), `Trade`, plus the tagged-union `FeedMessage` (type tag + union) and a `visit()` helper. `FeedMessage` is trivially copyable → lives in a queue slot with **no heap allocation**. |
| `Subscriber.hpp` | `SubscriberHandle` (opaque id) used to address/unsubscribe a subscriber. |
| `MarketDataPublisher.hpp/.cpp` | The publisher: fan-out, per-subscriber SPSC queues + worker threads, per-instrument sequence numbers, snapshots, drop-on-overflow, clean shutdown. |

### Design choices
- **One SPSC queue per subscriber** (`LockFreeQueue<FeedMessage, 8192>`), each
  drained by its own `std::jthread`. A slow subscriber can't block a fast one.
- **Tagged variant, one queue** carries all three message types, so ordering
  (e.g. a `Trade` between two `BookUpdate`s) is trivially preserved. Slot size =
  largest variant (`BookSnapshot`); snapshots are infrequent, so that's fine.
- **Per-instrument sequence numbers** (cache-line-padded counters). Gap =
  `received != last + 1`. A snapshot carries the seq it is consistent with and
  does **not** advance the counter (subscribers reset expected = seq + 1).
- **Copy-on-write subscriber list**: `atomic<shared_ptr<const vector>>`. The
  publish hot path never holds a mutex; subscribe/unsubscribe take a write lock
  and atomically swap an immutable snapshot.
- **Drop-on-overflow, never block**: the producer drop-counts when a queue is
  full instead of spinning, so one stalled subscriber can't stall the replay.

## Pipeline integration (`src/main/main.cpp`)
Behind the `ENABLE_MARKET_DATA_FEED` compile switch. After
`order_book_router_.apply(e)` the sink derives feed messages: `Add/Modify/Cancel`
→ `BookUpdate` with the new aggregated size from the book; `Trade` → `Trade`;
`Clear` → a fresh top-N `BookSnapshot` (`build_snapshot()` walks the router's
book). New subscribers are bootstrapped with a snapshot before any delta. End of
replay closes every subscriber queue so worker threads exit cleanly.

Router gained read accessors (`find_book` / resolved-instrument) so the feed can
read book state for snapshots without duplicating routing logic.

## Tests (`test/MarketDataPublisherTest.cpp`, Catch2)
Message round-trip + trivial-copyability; `visit` dispatch; per-instrument seq
independence; single-subscriber contiguous/in-order/no-drop; clean & idempotent
shutdown; unsubscribe stops delivery; subscribe-mid-stream gets snapshot-then-
deltas; `publishSnapshot` doesn't advance seq; per-instrument filtering;
multi-subscriber independent fan-out; stalled subscriber drops + **gap
detection**; **subscribe/unsubscribe under load** (3000 churn cycles vs a live
producer; FIFO never violated, gapless to the stable observer). All green
(`ctest`: 153/153).

## Benchmarks (`bench/MarketDataFeedBench.cpp`, google-benchmark, Release)
Aggregate delivered throughput (N×subscribers / time):

| Subscribers | Throughput |
|---|---|
| 1 | 2.61 M msg/s |
| 2 | 3.27 M msg/s |
| 4 | 3.97 M msg/s |
| 8 | 4.07 M msg/s |

Producer cost scales ~linearly with subscriber count (one copy per subscriber);
aggregate plateaus as the single producer saturates. Filter cost (set size 1 vs
10 instruments) is within noise — the `unordered_set` lookup is O(1).

To run on real data, download it to `root/data` folder and run:
```bash
BENCH_DIR=data/XEUR-20260409-HJTR7RCAKT1 BENCH_FILES=20 \
  ./build/bin/bench/back-tester-benchmarks --benchmark_filter=FeedApp
```


## Build / test / bench
```bash
cmake -B build -S .                 # configure (add -DCMAKE_BUILD_TYPE=Release for bench)
cmake --build build                 # serial build (low-RAM machines: avoid -j)
ctest --test-dir build              # all tests
./build/bin/test/back-tester-tests "[Feed]"
./build/bin/bench/back-tester-benchmarks --benchmark_filter=Feed
```